### PR TITLE
docs: align OSS docs and licensing

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,6 +32,6 @@ Enforcement decisions are final.
 
 ## Reporting
 
-If you experience or witness unacceptable behavior, report it privately to project maintainers.
+If you experience or witness unacceptable behavior, report it privately to project maintainers at [oss@modoterra.xyz](mailto:oss@modoterra.xyz).
 
 Please include as much detail as possible so maintainers can investigate appropriately.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Code of Conduct
+
+## Our Commitment
+
+We are committed to a respectful, harassment-free community focused on building useful software together.
+
+## Expected Behavior
+
+- Be respectful, constructive, and specific.
+- Assume good intent while reviewing technical decisions critically.
+- Focus on ideas and implementation, not personal attacks.
+- Welcome contributors with different backgrounds and experience levels.
+
+## Unacceptable Behavior
+
+- Harassment, discrimination, or hateful conduct.
+- Personal insults, intimidation, or sustained hostility.
+- Publishing private information without explicit consent.
+- Deliberate disruption of community collaboration.
+
+## Scope
+
+This code of conduct applies in repository spaces and project communication channels where contributors represent this project.
+
+## Enforcement
+
+Modoterra Corporation and its designated maintainers have sole and final discretion to interpret, apply, and enforce this Code of Conduct.
+
+To the maximum extent permitted by law, Modoterra Corporation may take any action it deems appropriate in response to conduct it considers harmful, disruptive, unsafe, unlawful, or inconsistent with project goals, including but not limited to warning, content removal, issue or pull request closure, contribution rejection, temporary suspension, permanent ban, or escalation to legal authorities.
+
+Enforcement decisions are final.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it privately to project maintainers.
+
+Please include as much detail as possible so maintainers can investigate appropriately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to Stasium
+
+Thanks for contributing.
+
+## Ground Rules
+
+- Keep pull requests small and focused.
+- Follow existing architecture and coding style.
+- Include tests for behavior changes.
+
+## Required Before Opening a PR
+
+Run and pass:
+
+```bash
+bun run lint
+bun run format:check
+bun run typecheck
+bun run test
+bun run build
+```
+
+## Commit Requirements
+
+### Conventional Commits (required)
+
+Use Conventional Commit messages, for example:
+
+- `feat: add manifest validation`
+- `fix: avoid duplicate service startup`
+- `docs: clarify release process`
+
+### Signed Commits (required)
+
+All commits must be signed.
+
+## Pull Request Expectations
+
+- Explain why the change is needed.
+- Include validation notes (what you ran and what passed).
+- Keep one concern per PR when possible.
+
+## Code of Conduct
+
+By participating, you agree to follow `CODE_OF_CONDUCT.md`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Modoterra Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ This project was created using `bun init` in bun v1.3.9. [Bun](https://bun.com) 
 
 See `CONTRIBUTING.md` for contribution workflow and required checks.
 
-Modoterra organization maintainers may bypass these requirements when necessary to keep deployments on schedule.
-
 ## Code of Conduct
 
 See `CODE_OF_CONDUCT.md`.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This project was created using `bun init` in bun v1.3.9. [Bun](https://bun.com) 
 
 See `CONTRIBUTING.md` for contribution workflow and required checks.
 
+Modoterra organization maintainers may bypass these requirements when necessary to keep deployments on schedule.
+
 ## Code of Conduct
 
 See `CODE_OF_CONDUCT.md`.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ Commit and branch rules:
   `feature`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`.
 
 This project was created using `bun init` in bun v1.3.9. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+
+## Contributing
+
+See `CONTRIBUTING.md` for contribution workflow and required checks.
+
+## Code of Conduct
+
+See `CODE_OF_CONDUCT.md`.
+
+## License
+
+MIT © 2026 Modoterra Corporation. See `LICENSE`.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "stasium",
+  "license": "MIT",
   "module": "index.ts",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary
- standardize project code of conduct language with Modoterra Corporation final enforcement authority
- add CONTRIBUTING.md and MIT LICENSE documents
- update package metadata and README references for OSS doc alignment