### PR TITLE
fix: centralize process definition normalization

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { type KeyEvent, createCliRenderer } from "@opentui/core";
 import { DockerManager, detectComposeFile } from "./docker";
 import { FocusManager } from "./focus";
@@ -11,6 +11,7 @@ import {
 } from "./init";
 import { loadManifest, parseServiceBlock, renderServiceBlock, saveManifest } from "./manifest";
 import { cleanupExistingPids, syncPidFiles } from "./pidfile";
+import { normalizeProcessDefinition } from "./process-definition";
 import { getTopologicalServiceOrder } from "./service-graph";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
@@ -248,7 +249,7 @@ const setupKeybindings = (
       controls.clearEditError();
       const toml = controls.getEditContent();
       try {
-        const config = parseServiceBlock(toml);
+        const config = parseServiceBlock(toml, dirname(manifestPath));
         const index = manager.getSelectedIndex();
         await manager.updateServiceConfig(index, config);
         await saveManifest(manifestPath, manager.getConfigs(), appConfig);
@@ -280,7 +281,9 @@ const setupKeybindings = (
       }
 
       try {
-        await manager.addService({ name, command });
+        await manager.addService(
+          normalizeProcessDefinition({ name, command }, { baseDir: dirname(manifestPath) }),
+        );
         await saveManifest(manifestPath, manager.getConfigs(), appConfig);
         await syncPids();
         controls.hideAddOverlay();

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,3 @@
-import { ManifestError } from "./manifest";
 import type { CommandSpec } from "./types";
 
 const tokenize = (input: string): string[] => {
@@ -36,7 +35,7 @@ const tokenize = (input: string): string[] => {
   }
 
   if (inSingle || inDouble) {
-    throw new ManifestError("command has unclosed quotes");
+    throw new Error("command has unclosed quotes");
   }
 
   if (current.length > 0) {
@@ -51,27 +50,27 @@ const forbiddenOperators = ["|", "&", ";", ">", "<", "`", "$"];
 const assertNoShellOperators = (argv: string[], raw: string) => {
   for (const op of forbiddenOperators) {
     if (raw.includes(op)) {
-      throw new ManifestError(
+      throw new Error(
         `command contains shell operator '${op}'. Use an argv array instead of shell syntax.`,
       );
     }
   }
   if (argv.length === 0) {
-    throw new ManifestError("command must not be empty");
+    throw new Error("command must not be empty");
   }
 };
 
 export const normalizeCommand = (command: CommandSpec): string[] => {
   if (Array.isArray(command)) {
     if (command.length === 0) {
-      throw new ManifestError("command array must not be empty");
+      throw new Error("command array must not be empty");
     }
     return command;
   }
 
   const raw = command.trim();
   if (raw.length === 0) {
-    throw new ManifestError("command must not be empty");
+    throw new Error("command must not be empty");
   }
 
   const tokens = tokenize(raw);

--- a/src/discovery/engine.test.ts
+++ b/src/discovery/engine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { detectDiscoveryCandidates } from "./engine";
 import { loadDiscoveryStrategies } from "./strategy-loader";
 import type { DiscoveryStrategy, StrategyWhen } from "./types";
@@ -67,6 +67,10 @@ describe("discovery engine", () => {
       expect(detected.warnings).toHaveLength(0);
       expect(detected.candidates).toHaveLength(1);
       expect(detected.candidates[0]?.service.command).toEqual(["bun", "run", "vite"]);
+      expect(detected.candidates[0]?.service.working_dir).toBe(resolve(dir));
+      expect(detected.candidates[0]?.service.env).toEqual({});
+      expect(detected.candidates[0]?.service.restart_policy).toBe("never");
+      expect(detected.candidates[0]?.service.depends_on).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/discovery/engine.ts
+++ b/src/discovery/engine.ts
@@ -1,4 +1,5 @@
-import type { ServiceConfig } from "../types";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "../process-definition";
+import type { CommandSpec, ServiceConfig } from "../types";
 import { resolveStrategyCaptures } from "./captures";
 import { DiscoveryProbeContext } from "./probes";
 import type { DetectResult, DetectedCandidate, DiscoveryStrategy, StrategyWhen } from "./types";
@@ -95,6 +96,7 @@ type ServiceBuildResult = {
 const buildCandidateService = (
   strategy: DiscoveryStrategy,
   captures: Record<string, string>,
+  cwd: string,
 ): ServiceBuildResult => {
   const renderedName = interpolate(strategy.service.name, captures);
   if (!renderedName || renderedName.trim().length === 0) {
@@ -105,7 +107,7 @@ const buildCandidateService = (
     };
   }
 
-  let renderedCommand: ServiceConfig["command"];
+  let renderedCommand: CommandSpec;
   if (Array.isArray(strategy.service.command)) {
     const parts: string[] = [];
     for (const part of strategy.service.command) {
@@ -177,7 +179,7 @@ const buildCandidateService = (
     }
   }
 
-  const service: ServiceConfig = {
+  const input: ProcessDefinitionInput = {
     name: renderedName,
     command: renderedCommand,
     working_dir: renderedWorkingDir,
@@ -186,11 +188,19 @@ const buildCandidateService = (
     depends_on: renderedDependsOn,
   };
 
-  return {
-    service,
-    dependsOnIds: strategy.service.depends_on_ids ?? [],
-    error: null,
-  };
+  try {
+    return {
+      service: normalizeProcessDefinition(input, { baseDir: cwd }),
+      dependsOnIds: strategy.service.depends_on_ids ?? [],
+      error: null,
+    };
+  } catch (error) {
+    return {
+      service: null,
+      dependsOnIds: [],
+      error: `Strategy '${strategy.id}' produced an invalid Process Definition: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
 };
 
 const toCandidate = (
@@ -226,7 +236,7 @@ export const detectDiscoveryCandidates = async (
       continue;
     }
 
-    const serviceResult = buildCandidateService(strategy, captureResolution.values);
+    const serviceResult = buildCandidateService(strategy, captureResolution.values, cwd);
     if (serviceResult.error || serviceResult.service === null) {
       if (serviceResult.error) {
         warnings.push(serviceResult.error);

--- a/src/discovery/selection.test.ts
+++ b/src/discovery/selection.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { normalizeProcessDefinition } from "../process-definition";
 import { DiscoverySelection, finalizeSelectedCandidates, finalizeSelection } from "./selection";
 import type { DetectedCandidate } from "./types";
 
@@ -13,10 +14,10 @@ const makeCandidate = (
   priority: 100,
   defaultSelected,
   dependsOnIds,
-  service: {
+  service: normalizeProcessDefinition({
     name,
     command: ["bun", "run", "dev"],
-  },
+  }),
 });
 
 describe("discovery selection", () => {

--- a/src/discovery/selection.ts
+++ b/src/discovery/selection.ts
@@ -10,11 +10,11 @@ interface FinalizeSelectionOptions {
 const cloneService = (service: ServiceConfig): ServiceConfig => {
   return {
     name: service.name,
-    command: Array.isArray(service.command) ? [...service.command] : service.command,
+    command: [...service.command],
     working_dir: service.working_dir,
-    env: service.env ? { ...service.env } : undefined,
+    env: { ...service.env },
     restart_policy: service.restart_policy,
-    depends_on: service.depends_on ? [...service.depends_on] : undefined,
+    depends_on: [...service.depends_on],
   };
 };
 
@@ -134,7 +134,7 @@ export const finalizeSelectedCandidates = (
     const service = services[index];
     if (!service) return;
 
-    const resolved = [...(service.depends_on ?? [])];
+    const resolved = [...service.depends_on];
     const seen = new Set(resolved);
 
     for (const dependencyId of candidate.dependsOnIds) {
@@ -155,7 +155,7 @@ export const finalizeSelectedCandidates = (
       seen.add(dependencyName);
     }
 
-    service.depends_on = resolved.length > 0 ? resolved : undefined;
+    service.depends_on = resolved;
   });
 
   return {

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -1,17 +1,24 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { ManifestError, loadManifest, renderManifest } from "./manifest";
-import type { AppConfig, ServiceConfig } from "./types";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
+import type { AppConfig } from "./types";
 
 const writeTempManifest = async (
-  services: ServiceConfig[],
+  services: ProcessDefinitionInput[],
   app?: AppConfig,
 ): Promise<{ manifestPath: string; dir: string }> => {
   const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
   const manifestPath = join(dir, "stasium.toml");
-  await Bun.write(manifestPath, renderManifest(services, app));
+  await Bun.write(
+    manifestPath,
+    renderManifest(
+      services.map((service) => normalizeProcessDefinition(service, { baseDir: dir })),
+      app,
+    ),
+  );
   return { manifestPath, dir };
 };
 
@@ -82,6 +89,85 @@ describe("manifest rendering", () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
     const manifestPath = join(dir, "stasium.toml");
     await Bun.write(manifestPath, ["[app.docker]", 'enabled = "no"'].join("\n"));
+
+    try {
+      await expect(loadManifest(manifestPath)).rejects.toThrow(ManifestError);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("loads normalized process definitions", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
+    const manifestPath = join(dir, "stasium.toml");
+    await Bun.write(
+      manifestPath,
+      [
+        "[[service]]",
+        'name = " db "',
+        'command = ["bun", "--version"]',
+        "",
+        "[[service]]",
+        'name = " api "',
+        'command = "bun run dev"',
+        'working_dir = "app"',
+        'depends_on = [" db "]',
+        "[service.env]",
+        "PORT = 3000",
+      ].join("\n"),
+    );
+
+    try {
+      const manifest = await loadManifest(manifestPath);
+      expect(manifest.services[0]).toMatchObject({
+        name: "db",
+        env: {},
+        restart_policy: "never",
+        depends_on: [],
+      });
+      expect(manifest.services[1]).toEqual({
+        name: "api",
+        command: ["bun", "run", "dev"],
+        working_dir: resolve(dir, "app"),
+        env: { PORT: "3000" },
+        restart_policy: "never",
+        depends_on: ["db"],
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects duplicate names after trimming", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
+    const manifestPath = join(dir, "stasium.toml");
+    await Bun.write(
+      manifestPath,
+      [
+        "[[service]]",
+        'name = "api"',
+        'command = ["bun", "--version"]',
+        "",
+        "[[service]]",
+        'name = " api "',
+        'command = ["bun", "--version"]',
+      ].join("\n"),
+    );
+
+    try {
+      await expect(loadManifest(manifestPath)).rejects.toThrow(ManifestError);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects shell-style launch instructions during loading", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
+    const manifestPath = join(dir, "stasium.toml");
+    await Bun.write(
+      manifestPath,
+      ["[[service]]", 'name = "api"', 'command = "bun run dev && bun run worker"'].join("\n"),
+    );
 
     try {
       await expect(loadManifest(manifestPath)).rejects.toThrow(ManifestError);

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,7 +1,13 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import {
+  ProcessDefinitionError,
+  normalizeProcessDefinition,
+  normalizeProcessDefinitions,
+  type ProcessDefinitionInput,
+} from "./process-definition";
 import { ServiceGraphError, validateServiceGraph } from "./service-graph";
 import { getErrorMessage } from "./shared";
-import type { AppConfig, AppDockerConfig, Manifest, ServiceConfig } from "./types";
+import type { AppConfig, AppDockerConfig, CommandSpec, Manifest, ServiceConfig } from "./types";
 
 type RawManifest = {
   app?: {
@@ -9,7 +15,16 @@ type RawManifest = {
       enabled?: boolean;
     };
   };
-  service?: ServiceConfig[];
+  service?: RawServiceConfig[];
+};
+
+type RawServiceConfig = {
+  name?: unknown;
+  command?: unknown;
+  working_dir?: unknown;
+  env?: unknown;
+  restart_policy?: unknown;
+  depends_on?: unknown;
 };
 
 const DEFAULT_MANIFEST = "stasium.toml";
@@ -34,7 +49,7 @@ const validRestartPolicies = new Set(["never", "on-failure", "always"]);
 const validAppKeys = new Set(["docker"]);
 const validDockerKeys = new Set(["enabled"]);
 
-const normalizeEnv = (env: unknown): Record<string, string> | undefined => {
+const coerceEnv = (env: unknown): Record<string, string> | undefined => {
   if (env === undefined) return undefined;
   if (env === null || typeof env !== "object" || Array.isArray(env)) {
     throw new ManifestError("service.env must be a table of string values");
@@ -97,7 +112,7 @@ const normalizeApp = (app: unknown): AppConfig | undefined => {
   return { docker };
 };
 
-const normalizeService = (raw: ServiceConfig, index: number): ServiceConfig => {
+const toProcessDefinitionInput = (raw: RawServiceConfig, index: number): ProcessDefinitionInput => {
   if (!raw || typeof raw !== "object") {
     throw new ManifestError(`service[${index}] must be a table`);
   }
@@ -107,11 +122,11 @@ const normalizeService = (raw: ServiceConfig, index: number): ServiceConfig => {
     throw new ManifestError(`service[${index}] has unknown keys: ${unknownKeys.join(", ")}`);
   }
 
-  if (!raw.name || typeof raw.name !== "string") {
+  if (typeof raw.name !== "string") {
     throw new ManifestError(`service[${index}].name must be a string`);
   }
 
-  if (!raw.command || (typeof raw.command !== "string" && !Array.isArray(raw.command))) {
+  if (typeof raw.command !== "string" && !Array.isArray(raw.command)) {
     throw new ManifestError(`service[${index}].command must be string or string[]`);
   }
 
@@ -137,16 +152,23 @@ const normalizeService = (raw: ServiceConfig, index: number): ServiceConfig => {
     }
   }
 
-  const env = normalizeEnv(raw.env);
+  const env = coerceEnv(raw.env);
 
   return {
     name: raw.name,
-    command: raw.command,
+    command: raw.command as CommandSpec,
     working_dir: raw.working_dir,
     env,
-    restart_policy: raw.restart_policy,
+    restart_policy: raw.restart_policy as ProcessDefinitionInput["restart_policy"],
     depends_on: raw.depends_on,
   };
+};
+
+const toManifestError = (error: unknown): never => {
+  if (error instanceof ProcessDefinitionError || error instanceof ServiceGraphError) {
+    throw new ManifestError(error.message);
+  }
+  throw error;
 };
 
 export const loadManifest = async (path?: string): Promise<Manifest> => {
@@ -170,15 +192,20 @@ export const loadManifest = async (path?: string): Promise<Manifest> => {
   }
 
   const app = normalizeApp(parsed.app);
-  const normalized = services.map((service, index) => normalizeService(service, index));
+  const inputs = services.map((service, index) => toProcessDefinitionInput(service, index));
+  const normalized = ((): ServiceConfig[] => {
+    try {
+      return normalizeProcessDefinitions(inputs, { baseDir: dirname(resolve(manifestPath)) });
+    } catch (error) {
+      toManifestError(error);
+    }
+    throw new ManifestError("Invalid Process Definition");
+  })();
 
   try {
     validateServiceGraph(normalized);
   } catch (error) {
-    if (error instanceof ServiceGraphError) {
-      throw new ManifestError(error.message);
-    }
-    throw error;
+    toManifestError(error);
   }
 
   return {
@@ -210,11 +237,11 @@ const renderServiceToml = (service: ServiceConfig): string => {
   if (service.restart_policy) {
     lines.push(`restart_policy = "${service.restart_policy}"`);
   }
-  if (service.depends_on && service.depends_on.length > 0) {
+  if (service.depends_on.length > 0) {
     const deps = service.depends_on.map((d) => `"${escapeToml(d)}"`).join(", ");
     lines.push(`depends_on = [${deps}]`);
   }
-  if (service.env && Object.keys(service.env).length > 0) {
+  if (Object.keys(service.env).length > 0) {
     lines.push("[service.env]");
     for (const [key, value] of Object.entries(service.env)) {
       lines.push(`"${escapeToml(key)}" = "${escapeToml(value)}"`);
@@ -257,7 +284,7 @@ export const renderServiceBlock = (service: ServiceConfig): string => {
   return renderServiceToml(service);
 };
 
-export const parseServiceBlock = (toml: string): ServiceConfig => {
+export const parseServiceBlock = (toml: string, baseDir?: string): ServiceConfig => {
   let parsed: RawManifest;
   try {
     parsed = Bun.TOML.parse(toml) as RawManifest;
@@ -275,7 +302,12 @@ export const parseServiceBlock = (toml: string): ServiceConfig => {
     throw new ManifestError("Expected exactly one [[service]] block");
   }
 
-  return normalizeService(raw, 0);
+  try {
+    return normalizeProcessDefinition(toProcessDefinitionInput(raw, 0), { baseDir });
+  } catch (error) {
+    toManifestError(error);
+  }
+  throw new ManifestError("Invalid service block");
 };
 
 export const saveManifest = async (

--- a/src/pidfile.test.ts
+++ b/src/pidfile.test.ts
@@ -6,6 +6,7 @@ import { resolve } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { readLiveProcessInfo } from "./process-info";
 import { cleanupExistingPids, setPidDirRootForTests, syncPidFiles } from "./pidfile";
+import { normalizeProcessDefinition } from "./process-definition";
 import { ServiceManager } from "./service-manager";
 
 const checksum = (value: string): string => createHash("md5").update(value).digest("hex");
@@ -70,10 +71,10 @@ describe("pidfile cleanup", () => {
 
     const { cwd, pidDir } = await createTestCwd();
     const manager = new ServiceManager([
-      {
+      normalizeProcessDefinition({
         name: "api",
         command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-      },
+      }),
     ]);
 
     try {

--- a/src/process-definition.ts
+++ b/src/process-definition.ts
@@ -1,0 +1,79 @@
+import { resolve } from "node:path";
+import { normalizeCommand } from "./command";
+import type { CommandSpec, RestartPolicy, ServiceConfig } from "./types";
+
+export interface ProcessDefinitionInput {
+  name: string;
+  command: CommandSpec;
+  working_dir?: string;
+  env?: Record<string, string>;
+  restart_policy?: RestartPolicy;
+  depends_on?: string[];
+}
+
+export interface NormalizeProcessDefinitionOptions {
+  baseDir?: string;
+}
+
+export class ProcessDefinitionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProcessDefinitionError";
+  }
+}
+
+const normalizeName = (name: string): string => {
+  const normalized = name.trim();
+  if (normalized.length === 0) {
+    throw new ProcessDefinitionError("service.name must not be empty");
+  }
+  return normalized;
+};
+
+const normalizeWorkingDir = (workingDir: string | undefined, baseDir?: string): string => {
+  const raw = workingDir?.trim() ?? ".";
+  if (raw.length === 0) {
+    throw new ProcessDefinitionError("service.working_dir must not be empty");
+  }
+  return resolve(baseDir ?? process.cwd(), raw);
+};
+
+const normalizeEnv = (env: Record<string, string> | undefined): Record<string, string> => {
+  return env ? { ...env } : {};
+};
+
+const normalizeDependencies = (dependencies: string[] | undefined): string[] => {
+  const normalized: string[] = [];
+  for (const dependency of dependencies ?? []) {
+    const name = dependency.trim();
+    if (name.length === 0) {
+      throw new ProcessDefinitionError("service.depends_on must not contain empty names");
+    }
+    normalized.push(name);
+  }
+  return normalized;
+};
+
+export const normalizeProcessDefinition = (
+  input: ProcessDefinitionInput,
+  options: NormalizeProcessDefinitionOptions = {},
+): ServiceConfig => {
+  try {
+    return {
+      name: normalizeName(input.name),
+      command: normalizeCommand(input.command),
+      working_dir: normalizeWorkingDir(input.working_dir, options.baseDir),
+      env: normalizeEnv(input.env),
+      restart_policy: input.restart_policy ?? "never",
+      depends_on: normalizeDependencies(input.depends_on),
+    };
+  } catch (error) {
+    if (error instanceof ProcessDefinitionError) throw error;
+    throw new ProcessDefinitionError(error instanceof Error ? error.message : String(error));
+  }
+};
+
+export const normalizeProcessDefinitions = (
+  inputs: ProcessDefinitionInput[],
+  options: NormalizeProcessDefinitionOptions = {},
+): ServiceConfig[] => inputs.map((input) => normalizeProcessDefinition(input, options));

--- a/src/service-graph.test.ts
+++ b/src/service-graph.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
 import {
   ServiceGraphError,
   getDependencyClosure,
@@ -9,21 +10,23 @@ import {
 } from "./service-graph";
 import type { ServiceConfig } from "./types";
 
+const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProcessDefinition(input);
+
 const baseServices: ServiceConfig[] = [
-  {
+  service({
     name: "api",
     command: ["bun", "run", "dev"],
     depends_on: ["db"],
-  },
-  {
+  }),
+  service({
     name: "db",
     command: ["docker", "compose", "up", "db"],
-  },
-  {
+  }),
+  service({
     name: "worker",
     command: ["bun", "run", "worker"],
     depends_on: ["api"],
-  },
+  }),
 ];
 
 describe("service graph", () => {
@@ -35,9 +38,9 @@ describe("service graph", () => {
     expect(getTopologicalServiceLayers(baseServices)).toEqual([["db"], ["api"], ["worker"]]);
     expect(
       getTopologicalServiceLayers([
-        { name: "db", command: ["bun", "--version"] },
-        { name: "cache", command: ["bun", "--version"] },
-        { name: "api", command: ["bun", "--version"], depends_on: ["db", "cache"] },
+        service({ name: "db", command: ["bun", "--version"] }),
+        service({ name: "cache", command: ["bun", "--version"] }),
+        service({ name: "api", command: ["bun", "--version"], depends_on: ["db", "cache"] }),
       ]),
     ).toEqual([["db", "cache"], ["api"]]);
   });
@@ -60,11 +63,11 @@ describe("service graph", () => {
 
   test("rejects unknown dependencies", () => {
     const services: ServiceConfig[] = [
-      {
+      service({
         name: "api",
         command: ["bun", "run", "dev"],
         depends_on: ["cache"],
-      },
+      }),
     ];
 
     expect(() => validateServiceGraph(services)).toThrow(ServiceGraphError);
@@ -72,16 +75,16 @@ describe("service graph", () => {
 
   test("rejects dependency cycles", () => {
     const services: ServiceConfig[] = [
-      {
+      service({
         name: "api",
         command: ["bun", "run", "dev"],
         depends_on: ["worker"],
-      },
-      {
+      }),
+      service({
         name: "worker",
         command: ["bun", "run", "worker"],
         depends_on: ["api"],
-      },
+      }),
     ];
 
     expect(() => validateServiceGraph(services)).toThrow(ServiceGraphError);

--- a/src/service-graph.ts
+++ b/src/service-graph.ts
@@ -7,7 +7,7 @@ export class ServiceGraphError extends Error {
   }
 }
 
-const dependenciesOf = (service: ServiceConfig): string[] => service.depends_on ?? [];
+const dependenciesOf = (service: ServiceConfig): string[] => service.depends_on;
 
 const buildServiceMap = (services: ServiceConfig[]): Map<string, ServiceConfig> => {
   const byName = new Map<string, ServiceConfig>();

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
 import { ServiceManager, ServiceManagerError } from "./service-manager";
 import type { ServiceConfig } from "./types";
 
-const makeConfig = (name: string): ServiceConfig => ({
-  name,
-  command: ["bun", "--version"],
-});
+const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProcessDefinition(input);
+
+const makeConfig = (name: string): ServiceConfig =>
+  service({
+    name,
+    command: ["bun", "--version"],
+  });
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -47,15 +51,15 @@ describe("ServiceManager", () => {
 
   test("starts dependencies before selected service", async () => {
     const manager = new ServiceManager([
-      {
+      service({
         name: "db",
         command: ["bun", "-e", "setTimeout(() => process.exit(0), 400)"],
-      },
-      {
+      }),
+      service({
         name: "api",
         command: ["bun", "-e", "setTimeout(() => process.exit(0), 400)"],
         depends_on: ["db"],
-      },
+      }),
     ]);
 
     manager.setSelectedIndex(1);
@@ -70,15 +74,15 @@ describe("ServiceManager", () => {
 
   test("stops selected dependency and its dependents", async () => {
     const manager = new ServiceManager([
-      {
+      service({
         name: "db",
         command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-      },
-      {
+      }),
+      service({
         name: "api",
         command: ["bun", "-e", "setInterval(() => {}, 1000)"],
         depends_on: ["db"],
-      },
+      }),
     ]);
 
     await manager.startAll();
@@ -100,10 +104,10 @@ describe("ServiceManager", () => {
     ].join(" ");
 
     const manager = new ServiceManager([
-      {
+      service({
         name: "stubborn",
         command: ["bun", "-e", stubbornScript],
-      },
+      }),
     ]);
 
     await manager.startAll();
@@ -119,16 +123,16 @@ describe("ServiceManager", () => {
   test("stops child processes spawned by services", async () => {
     const childScript = "setInterval(() => {}, 1000);";
     const parentScript = [
-      `const child = Bun.spawn({ cmd: [\"bun\", \"-e\", ${JSON.stringify(childScript)}], stdout: \"ignore\", stderr: \"ignore\" });`,
+      `const child = Bun.spawn({ cmd: ["bun", "-e", ${JSON.stringify(childScript)}], stdout: "ignore", stderr: "ignore" });`,
       "console.log(`child:${child.pid}`);",
       "setInterval(() => {}, 1000);",
     ].join(" ");
 
     const manager = new ServiceManager([
-      {
+      service({
         name: "tree",
         command: ["bun", "-e", parentScript],
-      },
+      }),
     ]);
 
     let childPid: number | null = null;
@@ -172,11 +176,11 @@ describe("ServiceManager", () => {
 
   test("restarts failed services with on-failure policy", async () => {
     const manager = new ServiceManager([
-      {
+      service({
         name: "failing",
         command: ["bun", "-e", "process.exit(1)"],
         restart_policy: "on-failure",
-      },
+      }),
     ]);
 
     await manager.startAll();

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -510,7 +510,7 @@ export class ServiceManager {
       return;
     }
 
-    const policy = view.config.restart_policy ?? "never";
+    const policy = view.config.restart_policy;
     if (policy === "never") return;
     if (policy === "on-failure" && exitCode === 0) return;
 

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { normalizeProcessDefinition } from "./process-definition";
 import { setPathReaderForTests, resetPathCacheForTests } from "./service";
 import { ServiceManager } from "./service-manager";
 
@@ -28,14 +29,14 @@ describe("service PATH cache", () => {
     });
 
     const manager = new ServiceManager([
-      {
+      normalizeProcessDefinition({
         name: "api",
         command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-      },
-      {
+      }),
+      normalizeProcessDefinition({
         name: "worker",
         command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-      },
+      }),
     ]);
 
     try {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,7 +1,6 @@
 import { readLiveProcessInfo, resolveRuntimeWorkingDir } from "./process-info";
-import { normalizeCommand } from "./command";
 import { getErrorMessage } from "./shared";
-import type { CommandSpec, LogEntry, ServiceConfig, ServicePid, ServiceState } from "./types";
+import type { LogEntry, ServiceConfig, ServicePid, ServiceState } from "./types";
 
 export type ServiceEvent =
   | { type: "state"; state: ServiceState }
@@ -156,26 +155,14 @@ export class ServiceProcess {
     this.identityVerified = false;
     this.setState("STARTING");
 
-    let argv: string[];
-    try {
-      argv = normalizeCommand(this.config.command as CommandSpec);
-      this.command = [...argv];
-    } catch (error) {
-      this.lastExitCode = 1;
-      this.lastSignal = null;
-      this.setState("FAILED");
-      this.emit({
-        type: "log",
-        entry: { timestamp: timestamp(), line: getErrorMessage(error), stream: "stderr" },
-      });
-      return;
-    }
+    const argv = this.config.command;
+    this.command = [...argv];
 
     try {
-      const env = await buildSpawnEnv(this.config.working_dir, this.config.env);
+      const env = await buildSpawnEnv(this.workingDir, this.config.env);
       this.process = Bun.spawn({
         cmd: argv,
-        cwd: this.config.working_dir,
+        cwd: this.workingDir,
         env,
         detached: this.detached,
         stdout: "pipe",

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,11 @@ export type CommandSpec = string | string[];
 
 export interface ServiceConfig {
   name: string;
-  command: CommandSpec;
-  working_dir?: string;
-  env?: Record<string, string>;
-  restart_policy?: RestartPolicy;
-  depends_on?: string[];
+  command: string[];
+  working_dir: string;
+  env: Record<string, string>;
+  restart_policy: RestartPolicy;
+  depends_on: string[];
 }
 
 export interface AppDockerConfig {


### PR DESCRIPTION
## Summary
- add a shared Process Definition normalizer for argv-ready launch instructions, absolute working directories, default restart rules, and empty env/dependency collections
- route manifest loading/editing, discovery candidates, and startup runtime types through normalized ServiceConfig values
- cover trimming, env coercion, defaulting, duplicate names, empty collections, and shell-style launch validation

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #7