### PR TITLE
fix: deepen discovery candidate selection

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -342,6 +342,7 @@ const setupKeybindings = (
 
         try {
           const finalized = finalizeSelection(selection, {
+            existingServices: manager.getConfigs(),
             usedNames: manager.getConfigs().map((config) => config.name),
           });
 

--- a/src/discovery/engine.test.ts
+++ b/src/discovery/engine.test.ts
@@ -113,6 +113,34 @@ describe("discovery engine", () => {
     }
   });
 
+  test("drops invalid raw candidate proposals with warnings", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-discovery-engine-"));
+
+    try {
+      const strategy: DiscoveryStrategy = {
+        id: "shell-style",
+        label: "Shell style",
+        priority: 100,
+        default_selected: true,
+        when: emptyWhen(),
+        capture: [],
+        service: {
+          name: "api",
+          command: "bun run dev && bun run worker",
+        },
+      };
+
+      const detected = await detectDiscoveryCandidates(dir, [strategy]);
+
+      expect(detected.candidates).toEqual([]);
+      expect(detected.warnings).toEqual([
+        "Strategy 'shell-style' produced an invalid Process Definition: command contains shell operator '&'. Use an argv array instead of shell syntax.",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("supports TOML path and regex predicates", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-discovery-engine-"));
 

--- a/src/discovery/selection.test.ts
+++ b/src/discovery/selection.test.ts
@@ -48,6 +48,7 @@ describe("discovery selection", () => {
     expect(finalized.services[0]?.name).toBe("app");
     expect(finalized.services[1]?.name).toBe("app-2");
     expect(finalized.services[1]?.depends_on).toEqual(["app"]);
+    expect(finalized.warnings).toContain("Candidate 'worker' was renamed from 'app' to 'app-2'.");
   });
 
   test("finalizeSelection uses current selected state", () => {
@@ -74,5 +75,63 @@ describe("discovery selection", () => {
 
     expect(finalized.services[0]?.name).toBe("app-2");
     expect(finalized.services[1]?.name).toBe("worker");
+    expect(finalized.warnings).toContain("Candidate 'app' was renamed from 'app' to 'app-2'.");
+  });
+
+  test("allows empty finalized results", () => {
+    const finalized = finalizeSelectedCandidates([]);
+
+    expect(finalized.services).toEqual([]);
+    expect(finalized.warnings).toEqual([]);
+  });
+
+  test("skips unaccepted candidate dependencies", () => {
+    const finalized = finalizeSelectedCandidates([
+      makeCandidate("worker", "worker", true, ["app"]),
+    ]);
+
+    expect(finalized.services[0]?.depends_on).toEqual([]);
+    expect(finalized.warnings).toEqual([]);
+  });
+
+  test("rejects finalized process definitions with invalid dependencies", () => {
+    expect(() =>
+      finalizeSelectedCandidates([
+        {
+          ...makeCandidate("api", "api"),
+          service: normalizeProcessDefinition({
+            name: "api",
+            command: ["bun", "run", "dev"],
+            depends_on: ["missing"],
+          }),
+        },
+      ]),
+    ).toThrow("depends on unknown service");
+  });
+
+  test("validates against existing process definitions when provided", () => {
+    const finalized = finalizeSelectedCandidates(
+      [
+        {
+          ...makeCandidate("api", "api"),
+          service: normalizeProcessDefinition({
+            name: "api",
+            command: ["bun", "run", "dev"],
+            depends_on: ["db"],
+          }),
+        },
+      ],
+      {
+        existingServices: [
+          normalizeProcessDefinition({
+            name: "db",
+            command: ["bun", "run", "db"],
+          }),
+        ],
+        usedNames: ["db"],
+      },
+    );
+
+    expect(finalized.services[0]?.depends_on).toEqual(["db"]);
   });
 });

--- a/src/discovery/selection.ts
+++ b/src/discovery/selection.ts
@@ -1,10 +1,19 @@
+import { ServiceGraphError, validateServiceGraph } from "../service-graph";
 import type { ServiceConfig } from "../types";
 import type { DetectedCandidate, FinalizeSelectionResult, SelectionItem } from "./types";
 
 export type DiscoverySelectionUpdateCallback = () => void;
 
 interface FinalizeSelectionOptions {
+  existingServices?: ServiceConfig[];
   usedNames?: Iterable<string>;
+}
+
+export class CandidateSelectionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CandidateSelectionError";
+  }
 }
 
 const cloneService = (service: ServiceConfig): ServiceConfig => {
@@ -124,6 +133,11 @@ export const finalizeSelectedCandidates = (
   for (const candidate of candidates) {
     const service = cloneService(candidate.service);
     const finalName = ensureUniqueName(service.name, usedNames);
+    if (finalName !== service.name) {
+      warnings.push(
+        `Candidate '${candidate.strategyId}' was renamed from '${service.name}' to '${finalName}'.`,
+      );
+    }
     usedNames.add(finalName);
     service.name = finalName;
     services.push(service);
@@ -158,10 +172,16 @@ export const finalizeSelectedCandidates = (
     service.depends_on = resolved;
   });
 
-  return {
-    services,
-    warnings,
-  };
+  try {
+    validateServiceGraph([...(options.existingServices ?? []), ...services]);
+  } catch (error) {
+    if (error instanceof ServiceGraphError) {
+      throw new CandidateSelectionError(error.message);
+    }
+    throw error;
+  }
+
+  return { services, warnings };
 };
 
 export const finalizeSelection = (


### PR DESCRIPTION
## Summary
- keep invalid raw Discovery candidate proposals out of selectable results with explicit warnings
- make Candidate Selection warn when unique-name generation renames a Candidate
- validate finalized Process Definitions, including against existing Workspace definitions when provided
- keep empty Candidate Selection results valid at the Module level while callers enforce non-empty policies

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #8