### PR TITLE
feat: add startup dependency planning

### DIFF
--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -1,13 +1,7 @@
 import { LogBuffer } from "./log-buffer";
 import { type ServiceEvent, ServiceProcess } from "./service";
-import {
-  ServiceGraphError,
-  getDependencyClosure,
-  getDependentsClosure,
-  getTopologicalServiceLayers,
-  getTopologicalServiceOrder,
-  validateServiceGraph,
-} from "./service-graph";
+import { ServiceGraphError, getDependencyClosure, getDependentsClosure } from "./service-graph";
+import { StartupDependencyPlanError, planStartupDependencies } from "./startup-dependency-plan";
 import type { ServiceConfig, ServicePid, ServiceState } from "./types";
 
 export interface ServiceView {
@@ -135,22 +129,16 @@ export class ServiceManager {
   }
 
   async stopAll(): Promise<void> {
-    await this.forEachResolvedService(
-      this.getTopologicalOrderNames().reverse(),
-      async (service) => {
-        await this.stopService(service);
-      },
-    );
+    await this.forEachResolvedService(this.getShutdownOrderNames(), async (service) => {
+      await this.stopService(service);
+    });
   }
 
   async forceStopAll(): Promise<void> {
-    await this.forEachResolvedService(
-      this.getTopologicalOrderNames().reverse(),
-      async (service) => {
-        this.suppressAutoRestart(service);
-        await service.forceStop("SIGKILL");
-      },
-    );
+    await this.forEachResolvedService(this.getShutdownOrderNames(), async (service) => {
+      this.suppressAutoRestart(service);
+      await service.forceStop("SIGKILL");
+    });
   }
 
   async startSelected(): Promise<void> {
@@ -366,7 +354,7 @@ export class ServiceManager {
     try {
       return operation();
     } catch (error) {
-      if (error instanceof ServiceGraphError) {
+      if (error instanceof ServiceGraphError || error instanceof StartupDependencyPlanError) {
         throw new ServiceManagerError(error.message);
       }
       throw error;
@@ -375,16 +363,20 @@ export class ServiceManager {
 
   private assertValidConfigGraph(configs: ServiceConfig[]): void {
     this.runGraphOperation(() => {
-      validateServiceGraph(configs);
+      planStartupDependencies(configs);
     });
   }
 
   private getTopologicalOrderNames(): string[] {
-    return this.runGraphOperation(() => getTopologicalServiceOrder(this.getConfigs()));
+    return this.runGraphOperation(() => planStartupDependencies(this.getConfigs()).startupOrder);
+  }
+
+  private getShutdownOrderNames(): string[] {
+    return this.runGraphOperation(() => planStartupDependencies(this.getConfigs()).shutdownOrder);
   }
 
   private getTopologicalLayers(): string[][] {
-    return this.runGraphOperation(() => getTopologicalServiceLayers(this.getConfigs()));
+    return this.runGraphOperation(() => planStartupDependencies(this.getConfigs()).startupLayers);
   }
 
   private getStartOrderForService(name: string): string[] {

--- a/src/startup-dependency-plan.test.ts
+++ b/src/startup-dependency-plan.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
+import {
+  StartupDependencyPlanError,
+  getBlockedProcessStates,
+  planStartupDependencies,
+} from "./startup-dependency-plan";
+import type { ServiceConfig } from "./types";
+
+const processDefinition = (input: ProcessDefinitionInput): ServiceConfig =>
+  normalizeProcessDefinition(input);
+
+describe("Startup Dependency planning", () => {
+  test("computes Startup order and reverse Shutdown order", () => {
+    const plan = planStartupDependencies([
+      processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+      processDefinition({ name: "db", command: ["bun", "run", "db"] }),
+      processDefinition({
+        name: "worker",
+        command: ["bun", "run", "worker"],
+        depends_on: ["api"],
+      }),
+    ]);
+
+    expect(plan.startupOrder).toEqual(["db", "api", "worker"]);
+    expect(plan.shutdownOrder).toEqual(["worker", "api", "db"]);
+    expect(plan.startupLayers).toEqual([["db"], ["api"], ["worker"]]);
+  });
+
+  test("validates duplicate names, unknown dependencies, self-dependencies, and cycles", () => {
+    expect(() =>
+      planStartupDependencies([
+        processDefinition({ name: "api", command: ["bun", "run", "dev"] }),
+        processDefinition({ name: "api", command: ["bun", "run", "worker"] }),
+      ]),
+    ).toThrow(StartupDependencyPlanError);
+
+    expect(() =>
+      planStartupDependencies([
+        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+      ]),
+    ).toThrow(StartupDependencyPlanError);
+
+    expect(() =>
+      planStartupDependencies([
+        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["api"] }),
+      ]),
+    ).toThrow(StartupDependencyPlanError);
+
+    expect(() =>
+      planStartupDependencies([
+        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["worker"] }),
+        processDefinition({
+          name: "worker",
+          command: ["bun", "run", "worker"],
+          depends_on: ["api"],
+        }),
+      ]),
+    ).toThrow(StartupDependencyPlanError);
+  });
+
+  test("represents blocked Process State when Startup Dependencies fail", () => {
+    const plan = planStartupDependencies([
+      processDefinition({ name: "db", command: ["bun", "run", "db"] }),
+      processDefinition({ name: "cache", command: ["bun", "run", "cache"] }),
+      processDefinition({
+        name: "api",
+        command: ["bun", "run", "dev"],
+        depends_on: ["db", "cache"],
+      }),
+      processDefinition({
+        name: "worker",
+        command: ["bun", "run", "worker"],
+        depends_on: ["api"],
+      }),
+    ]);
+
+    expect(getBlockedProcessStates(plan, ["db"])).toEqual([
+      {
+        name: "api",
+        state: "BLOCKED",
+        blockedBy: ["db"],
+        reason: 'Startup Dependency "db" failed to become available.',
+      },
+      {
+        name: "worker",
+        state: "BLOCKED",
+        blockedBy: ["api"],
+        reason: 'Startup Dependency "api" failed to become available.',
+      },
+    ]);
+  });
+});

--- a/src/startup-dependency-plan.ts
+++ b/src/startup-dependency-plan.ts
@@ -1,0 +1,98 @@
+import {
+  ServiceGraphError,
+  getTopologicalServiceLayers,
+  getTopologicalServiceOrder,
+  validateServiceGraph,
+} from "./service-graph";
+import type { ServiceConfig } from "./types";
+
+export type BlockedProcessState = {
+  name: string;
+  state: "BLOCKED";
+  blockedBy: string[];
+  reason: string;
+};
+
+export interface StartupDependencyPlan {
+  processDefinitions: ServiceConfig[];
+  startupOrder: string[];
+  startupLayers: string[][];
+  shutdownOrder: string[];
+}
+
+export class StartupDependencyPlanError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StartupDependencyPlanError";
+  }
+}
+
+const toPlanningError = (error: unknown): never => {
+  if (error instanceof ServiceGraphError) {
+    throw new StartupDependencyPlanError(error.message);
+  }
+  throw error;
+};
+
+const cloneProcessDefinitions = (processDefinitions: ServiceConfig[]): ServiceConfig[] =>
+  processDefinitions.map((processDefinition) => ({
+    name: processDefinition.name,
+    command: [...processDefinition.command],
+    working_dir: processDefinition.working_dir,
+    env: { ...processDefinition.env },
+    restart_policy: processDefinition.restart_policy,
+    depends_on: [...processDefinition.depends_on],
+  }));
+
+export const planStartupDependencies = (
+  processDefinitions: ServiceConfig[],
+): StartupDependencyPlan => {
+  const cloned = cloneProcessDefinitions(processDefinitions);
+
+  try {
+    validateServiceGraph(cloned);
+    const startupOrder = getTopologicalServiceOrder(cloned);
+    return {
+      processDefinitions: cloned,
+      startupOrder,
+      startupLayers: getTopologicalServiceLayers(cloned),
+      shutdownOrder: [...startupOrder].reverse(),
+    };
+  } catch (error) {
+    toPlanningError(error);
+  }
+  throw new StartupDependencyPlanError("Invalid Startup Dependency plan");
+};
+
+export const getBlockedProcessStates = (
+  plan: StartupDependencyPlan,
+  unavailableNames: Iterable<string>,
+): BlockedProcessState[] => {
+  const unavailable = new Set(unavailableNames);
+  const blocked: BlockedProcessState[] = [];
+  const byName = new Map(
+    plan.processDefinitions.map((processDefinition) => [processDefinition.name, processDefinition]),
+  );
+
+  for (const name of plan.startupOrder) {
+    if (unavailable.has(name)) continue;
+
+    const processDefinition = byName.get(name);
+    if (!processDefinition) continue;
+
+    const blockedBy = processDefinition.depends_on.filter((dependency) =>
+      unavailable.has(dependency),
+    );
+    if (blockedBy.length === 0) continue;
+
+    unavailable.add(name);
+    blocked.push({
+      name,
+      state: "BLOCKED",
+      blockedBy,
+      reason: `Startup Dependency ${blockedBy.map((dependency) => `"${dependency}"`).join(", ")} failed to become available.`,
+    });
+  }
+
+  return blocked;
+};


### PR DESCRIPTION
## Summary
- add a Startup Dependency planning module for normalized Process Definitions
- validate duplicate names, unknown dependencies, self-dependencies, and cycles through planning-specific errors
- compute Startup order, Startup layers, and reverse Shutdown order without runtime effects
- represent blocked Process State for dependents when Startup Dependencies fail to become available
- route all-process ServiceManager startup/shutdown ordering through the planner

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #9