### PR TITLE
feat: add launch instruction execution adapter

### DIFF
--- a/src/launch-execution.test.ts
+++ b/src/launch-execution.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import { LaunchInstructionExecutionAdapter, type LaunchExecutionEvent } from "./launch-execution";
+
+const streamFrom = (chunks: string[]): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+};
+
+const flush = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe("LaunchInstructionExecutionAdapter", () => {
+  test("spawns with normalized argv, working directory, environment, and instance PATH cache", async () => {
+    const spawned: Array<{ cmd: string[]; cwd: string; env: NodeJS.ProcessEnv }> = [];
+    let pathReads = 0;
+    const adapter = new LaunchInstructionExecutionAdapter({
+      pathReader: async () => {
+        pathReads += 1;
+        return "/fresh/bin";
+      },
+      processInfoReader: async () => ({ pid: 101, startedAt: "started", command: "bun" }),
+      spawner: (options) => {
+        spawned.push({ cmd: options.cmd, cwd: options.cwd, env: options.env });
+        return {
+          pid: 101,
+          stdout: null,
+          stderr: null,
+          exited: new Promise(() => {}),
+          signalCode: null,
+          kill: () => {},
+        };
+      },
+    });
+
+    await adapter.start(
+      { argv: ["bun", "run", "dev"], workingDir: "/project", env: { PORT: "3000" } },
+      () => {},
+    );
+    await adapter.start(
+      { argv: ["bun", "run", "worker"], workingDir: "/project", env: {} },
+      () => {},
+    );
+
+    expect(pathReads).toBe(1);
+    expect(spawned[0]).toMatchObject({
+      cmd: ["bun", "run", "dev"],
+      cwd: "/project",
+      env: { PATH: "/fresh/bin", PORT: "3000" },
+    });
+    expect(spawned[1]?.env.PATH).toBe("/fresh/bin");
+  });
+
+  test("emits structured spawn failure and Process Output", async () => {
+    const events: LaunchExecutionEvent[] = [];
+    const adapter = new LaunchInstructionExecutionAdapter({
+      now: () => "now",
+      pathReader: async () => "/fresh/bin",
+      spawner: () => {
+        throw new Error("spawn failed");
+      },
+    });
+
+    const handle = await adapter.start(
+      { argv: ["missing"], workingDir: "/project", env: {} },
+      (event) => events.push(event),
+    );
+
+    expect(handle).toBeNull();
+    expect(events).toEqual([
+      { type: "spawn-failed", message: "spawn failed" },
+      {
+        type: "output",
+        entry: { timestamp: "now", line: "spawn failed", stream: "stderr" },
+      },
+    ]);
+  });
+
+  test("emits output and exit events without launching OS processes", async () => {
+    const events: LaunchExecutionEvent[] = [];
+    const adapter = new LaunchInstructionExecutionAdapter({
+      now: () => "now",
+      pathReader: async () => "/fresh/bin",
+      processInfoReader: async () => null,
+      spawner: () => ({
+        pid: 202,
+        stdout: streamFrom(["hello\npartial"]),
+        stderr: streamFrom(["warn\n"]),
+        exited: Promise.resolve(7),
+        signalCode: "SIGTERM",
+        kill: () => {},
+      }),
+    });
+
+    await adapter.start({ argv: ["bun"], workingDir: "/project", env: {} }, (event) =>
+      events.push(event),
+    );
+    await flush();
+
+    expect(events).toContainEqual({
+      type: "started",
+      pid: 202,
+      startedAt: "now",
+      identityVerified: false,
+    });
+    expect(events).toContainEqual({
+      type: "output",
+      entry: { timestamp: "now", line: "hello", stream: "stdout" },
+    });
+    expect(events).toContainEqual({
+      type: "output",
+      entry: { timestamp: "now", line: "partial", stream: "stdout" },
+    });
+    expect(events).toContainEqual({ type: "exit", code: 7, signal: "SIGTERM" });
+  });
+
+  test("signals process groups before falling back to direct process signals", async () => {
+    const killed: NodeJS.Signals[] = [];
+    const groups: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const adapter = new LaunchInstructionExecutionAdapter({
+      pathReader: async () => "/fresh/bin",
+      processInfoReader: async () => null,
+      signalProcessGroup: (pid, signal) => {
+        groups.push({ pid, signal });
+        return true;
+      },
+      spawner: () => ({
+        pid: 303,
+        stdout: null,
+        stderr: null,
+        exited: new Promise(() => {}),
+        signalCode: null,
+        kill: (signal) => killed.push(signal),
+      }),
+    });
+
+    const handle = await adapter.start(
+      { argv: ["bun"], workingDir: "/project", env: {}, detached: true },
+      () => {},
+    );
+
+    handle?.signal("SIGINT");
+    expect(groups).toEqual([{ pid: 303, signal: "SIGINT" }]);
+    expect(killed).toEqual([]);
+  });
+});

--- a/src/launch-execution.ts
+++ b/src/launch-execution.ts
@@ -1,0 +1,260 @@
+import { readLiveProcessInfo, type LiveProcessInfo } from "./process-info";
+import type { LogEntry } from "./types";
+
+export type LaunchExecutionEvent =
+  | {
+      type: "started";
+      pid: number;
+      startedAt: string;
+      identityVerified: boolean;
+    }
+  | { type: "output"; entry: LogEntry }
+  | { type: "spawn-failed"; message: string }
+  | { type: "exit"; code: number | null; signal: string | null };
+
+export interface LaunchInstructionInput {
+  argv: string[];
+  workingDir: string;
+  env: Record<string, string>;
+  detached?: boolean;
+}
+
+export interface LaunchExecutionHandle {
+  pid: number;
+  signal: (signal: NodeJS.Signals) => void;
+}
+
+type LaunchEventHandler = (event: LaunchExecutionEvent) => void;
+type PathReader = (cwd: string) => Promise<string | null>;
+type ProcessInfoReader = (pid: number) => Promise<LiveProcessInfo | null>;
+type SignalProcessGroup = (pid: number, signal: NodeJS.Signals) => boolean;
+
+type AdapterSubprocess = {
+  pid: number;
+  stdout: ReadableStream<Uint8Array> | null;
+  stderr: ReadableStream<Uint8Array> | null;
+  exited: Promise<number | null>;
+  signalCode?: string | null;
+  kill: (signal: NodeJS.Signals) => void;
+};
+
+type SpawnOptions = {
+  cmd: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  detached: boolean;
+  stdout: "pipe";
+  stderr: "pipe";
+};
+
+type Spawner = (options: SpawnOptions) => AdapterSubprocess;
+
+interface LaunchInstructionExecutionAdapterOptions {
+  now?: () => string;
+  pathReader?: PathReader;
+  processInfoReader?: ProcessInfoReader;
+  signalProcessGroup?: SignalProcessGroup;
+  spawner?: Spawner;
+}
+
+const lineDecoder = new TextDecoder();
+
+const timestamp = (): string => new Date().toISOString();
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return String(error);
+};
+
+const splitLines = (buffer: string): { lines: string[]; rest: string } => {
+  const parts = buffer.split(/\r?\n/);
+  const rest = parts.pop() ?? "";
+  return { lines: parts, rest };
+};
+
+const resolveShell = (): string => {
+  const shell = process.env.SHELL;
+  if (shell && shell.trim().length > 0) return shell;
+  return "/bin/sh";
+};
+
+const readPathFromShell = async (cwd: string): Promise<string | null> => {
+  try {
+    const proc = Bun.spawn({
+      cmd: [resolveShell(), "-lc", "printenv PATH"],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+    const freshPath = output.trim();
+    return freshPath.length > 0 ? freshPath : null;
+  } catch {
+    return null;
+  }
+};
+
+const spawnWithBun: Spawner = (options) =>
+  Bun.spawn({
+    cmd: options.cmd,
+    cwd: options.cwd,
+    env: options.env,
+    detached: options.detached,
+    stdout: options.stdout,
+    stderr: options.stderr,
+  });
+
+const signalUnixProcessGroup: SignalProcessGroup = (pid, signal) => {
+  if (process.platform === "win32") return false;
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    return code === "ESRCH";
+  }
+};
+
+export class LaunchInstructionExecutionAdapter {
+  private cachedPath: string | null = null;
+  private pathRefreshPromise: Promise<string> | null = null;
+  private readonly now: () => string;
+  private readonly pathReader: PathReader;
+  private readonly processInfoReader: ProcessInfoReader;
+  private readonly signalProcessGroup: SignalProcessGroup;
+  private readonly spawner: Spawner;
+
+  constructor(options: LaunchInstructionExecutionAdapterOptions = {}) {
+    this.now = options.now ?? timestamp;
+    this.pathReader = options.pathReader ?? readPathFromShell;
+    this.processInfoReader = options.processInfoReader ?? readLiveProcessInfo;
+    this.signalProcessGroup = options.signalProcessGroup ?? signalUnixProcessGroup;
+    this.spawner = options.spawner ?? spawnWithBun;
+  }
+
+  async start(
+    input: LaunchInstructionInput,
+    onEvent: LaunchEventHandler,
+  ): Promise<LaunchExecutionHandle | null> {
+    const env = await this.buildSpawnEnv(input.workingDir, input.env);
+    let proc: AdapterSubprocess;
+
+    try {
+      proc = this.spawner({
+        cmd: input.argv,
+        cwd: input.workingDir,
+        env,
+        detached: input.detached ?? false,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      onEvent({ type: "spawn-failed", message });
+      onEvent({
+        type: "output",
+        entry: { timestamp: this.now(), line: message, stream: "stderr" },
+      });
+      return null;
+    }
+
+    const processInfo = await this.processInfoReader(proc.pid);
+    onEvent({
+      type: "started",
+      pid: proc.pid,
+      startedAt: processInfo?.startedAt ?? this.now(),
+      identityVerified: processInfo !== null,
+    });
+
+    this.attachStream(proc.stdout, "stdout", onEvent);
+    this.attachStream(proc.stderr, "stderr", onEvent);
+    void proc.exited
+      .then((code) => {
+        onEvent({ type: "exit", code, signal: proc.signalCode ?? null });
+      })
+      .catch((error) => {
+        onEvent({
+          type: "output",
+          entry: { timestamp: this.now(), line: getErrorMessage(error), stream: "stderr" },
+        });
+      });
+
+    return {
+      pid: proc.pid,
+      signal: (signal) => {
+        if (input.detached && this.signalProcessGroup(proc.pid, signal)) return;
+        proc.kill(signal);
+      },
+    };
+  }
+
+  private async getFreshPath(cwd: string): Promise<string> {
+    if (this.cachedPath !== null) return this.cachedPath;
+    if (this.pathRefreshPromise) return this.pathRefreshPromise;
+
+    this.pathRefreshPromise = (async () => {
+      const freshPath = await this.pathReader(cwd);
+      this.cachedPath = freshPath ?? process.env.PATH ?? "";
+      return this.cachedPath;
+    })();
+
+    try {
+      return await this.pathRefreshPromise;
+    } finally {
+      this.pathRefreshPromise = null;
+    }
+  }
+
+  private async buildSpawnEnv(
+    cwd: string,
+    overrides: Record<string, string>,
+  ): Promise<NodeJS.ProcessEnv> {
+    const freshPath = await this.getFreshPath(cwd);
+    return { ...process.env, PATH: freshPath, ...overrides };
+  }
+
+  private attachStream(
+    stream: ReadableStream<Uint8Array> | null,
+    source: "stdout" | "stderr",
+    onEvent: LaunchEventHandler,
+  ): void {
+    if (!stream) return;
+    const reader = stream.getReader();
+    let remainder = "";
+
+    const readLoop = async () => {
+      while (true) {
+        const result = await reader.read();
+        if (result.done) break;
+
+        remainder += lineDecoder.decode(result.value);
+        const lines = splitLines(remainder);
+        remainder = lines.rest;
+
+        for (const line of lines.lines) {
+          onEvent({
+            type: "output",
+            entry: { timestamp: this.now(), line, stream: source },
+          });
+        }
+      }
+
+      if (remainder.length > 0) {
+        onEvent({
+          type: "output",
+          entry: { timestamp: this.now(), line: remainder, stream: source },
+        });
+      }
+    };
+
+    void readLoop().catch((error) => {
+      onEvent({
+        type: "output",
+        entry: { timestamp: this.now(), line: getErrorMessage(error), stream: "stderr" },
+      });
+    });
+  }
+}

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -1,4 +1,5 @@
 import { LogBuffer } from "./log-buffer";
+import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { type ServiceEvent, ServiceProcess } from "./service";
 import {
   ServiceGraphError,
@@ -21,6 +22,10 @@ export interface ServiceView {
 }
 
 export type UpdateCallback = () => void;
+
+export interface ServiceManagerOptions {
+  launchAdapter?: LaunchInstructionExecutionAdapter;
+}
 
 const LOG_CAPACITY = 2000;
 const WAIT_INTERVAL_MS = 50;
@@ -45,14 +50,16 @@ export class ServiceManager {
   private readonly restartAttempts: Map<ServiceProcess, number> = new Map();
   private readonly restartDeadlines: Map<ServiceProcess, number> = new Map();
   private readonly runStableTimers: Map<ServiceProcess, ReturnType<typeof setTimeout>> = new Map();
+  private readonly launchAdapter: LaunchInstructionExecutionAdapter;
   private restartTicker: ReturnType<typeof setInterval> | null = null;
   private readonly updateCallbacks: Set<UpdateCallback> = new Set();
   private readonly processCallbacks: Set<UpdateCallback> = new Set();
   private selectedIndex = 0;
 
-  constructor(configs: ServiceConfig[]) {
+  constructor(configs: ServiceConfig[], options: ServiceManagerOptions = {}) {
     this.assertValidConfigGraph(configs);
-    this.services = configs.map((config) => new ServiceProcess(config));
+    this.launchAdapter = options.launchAdapter ?? new LaunchInstructionExecutionAdapter();
+    this.services = configs.map((config) => new ServiceProcess(config, this.launchAdapter));
     this.views = this.services.map((service) => ({
       name: service.config.name,
       state: "STOPPED",
@@ -216,7 +223,7 @@ export class ServiceManager {
 
     this.assertValidConfigGraph([...this.getConfigs(), config]);
 
-    const process = new ServiceProcess(config);
+    const process = new ServiceProcess(config, this.launchAdapter);
     this.services.push(process);
     this.views.push({
       name: config.name,
@@ -276,7 +283,7 @@ export class ServiceManager {
     this.clearServiceRuntimeState(oldService);
     this.unsubscribers[index]?.();
 
-    const newProcess = new ServiceProcess(config);
+    const newProcess = new ServiceProcess(config, this.launchAdapter);
     this.services[index] = newProcess;
 
     const view = this.views[index];

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -1,51 +1,51 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { normalizeProcessDefinition } from "./process-definition";
-import { setPathReaderForTests, resetPathCacheForTests } from "./service";
 import { ServiceManager } from "./service-manager";
 
-const waitFor = async (
-  predicate: () => boolean,
-  timeoutMs = 2000,
-  intervalMs = 25,
-): Promise<boolean> => {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (predicate()) return true;
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-  }
-  return predicate();
-};
-
-afterEach(() => {
-  resetPathCacheForTests();
-});
-
-describe("service PATH cache", () => {
-  test("reads PATH from the shell once per app session", async () => {
-    let reads = 0;
-    setPathReaderForTests(async () => {
-      reads += 1;
-      return process.env.PATH ?? "";
+describe("ServiceManager launch execution", () => {
+  test("shares one Launch Instruction execution Adapter across managed processes", async () => {
+    let pathReads = 0;
+    const spawned: string[][] = [];
+    const launchAdapter = new LaunchInstructionExecutionAdapter({
+      pathReader: async () => {
+        pathReads += 1;
+        return process.env.PATH ?? "";
+      },
+      processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+      spawner: (options) => {
+        spawned.push(options.cmd);
+        return {
+          pid: spawned.length,
+          stdout: null,
+          stderr: null,
+          exited: new Promise(() => {}),
+          signalCode: null,
+          kill: () => {},
+        };
+      },
     });
 
-    const manager = new ServiceManager([
-      normalizeProcessDefinition({
-        name: "api",
-        command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-      }),
-      normalizeProcessDefinition({
-        name: "worker",
-        command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-      }),
-    ]);
+    const manager = new ServiceManager(
+      [
+        normalizeProcessDefinition({
+          name: "api",
+          command: ["bun", "run", "dev"],
+        }),
+        normalizeProcessDefinition({
+          name: "worker",
+          command: ["bun", "run", "worker"],
+        }),
+      ],
+      { launchAdapter },
+    );
 
-    try {
-      await manager.startAll();
-      const started = await waitFor(() => manager.getServicePids().length === 2);
-      expect(started).toBe(true);
-      expect(reads).toBe(1);
-    } finally {
-      await manager.stopAll();
-    }
+    await manager.startAll();
+
+    expect(pathReads).toBe(1);
+    expect(spawned).toEqual([
+      ["bun", "run", "dev"],
+      ["bun", "run", "worker"],
+    ]);
   });
 });

--- a/src/service.ts
+++ b/src/service.ts
@@ -85,7 +85,7 @@ export class ServiceProcess {
 
     const argv = this.config.command;
     this.command = [...argv];
-    this.launchHandle = await this.launchAdapter.start(
+    const launchHandle = await this.launchAdapter.start(
       {
         argv,
         workingDir: this.workingDir,
@@ -94,6 +94,9 @@ export class ServiceProcess {
       },
       (event) => this.handleLaunchEvent(event),
     );
+    if (launchHandle && this.state === "RUNNING") {
+      this.launchHandle = launchHandle;
+    }
   }
 
   async stop(signal: NodeJS.Signals = "SIGINT"): Promise<void> {

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,5 +1,9 @@
-import { readLiveProcessInfo, resolveRuntimeWorkingDir } from "./process-info";
-import { getErrorMessage } from "./shared";
+import {
+  LaunchInstructionExecutionAdapter,
+  type LaunchExecutionEvent,
+  type LaunchExecutionHandle,
+} from "./launch-execution";
+import { resolveRuntimeWorkingDir } from "./process-info";
 import type { LogEntry, ServiceConfig, ServicePid, ServiceState } from "./types";
 
 export type ServiceEvent =
@@ -9,91 +13,16 @@ export type ServiceEvent =
 
 type ServiceSubscriber = (event: ServiceEvent) => void;
 
-const timestamp = (): string => new Date().toISOString();
-
-const lineDecoder = new TextDecoder();
 // Full process-tree cleanup relies on Unix process groups. Windows falls back to the direct child.
 const SHOULD_DETACH_PROCESS_GROUP = process.platform !== "win32";
-
-const splitLines = (buffer: string): { lines: string[]; rest: string } => {
-  const parts = buffer.split(/\r?\n/);
-  const rest = parts.pop() ?? "";
-  return { lines: parts, rest };
-};
-
-const resolveShell = (): string => {
-  const shell = process.env.SHELL;
-  if (shell && shell.trim().length > 0) return shell;
-  return "/bin/sh";
-};
-
-type PathReader = (cwd?: string) => Promise<string | null>;
-
-let pathRefreshPromise: Promise<string> | null = null;
-let cachedPath: string | null = null;
-
-const readPathFromShell = async (cwd?: string): Promise<string | null> => {
-  try {
-    const proc = Bun.spawn({
-      cmd: [resolveShell(), "-lc", "printenv PATH"],
-      cwd,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const output = await new Response(proc.stdout).text();
-    await proc.exited;
-    const freshPath = output.trim();
-    return freshPath.length > 0 ? freshPath : null;
-  } catch {
-    return null;
-  }
-};
-
-let pathReader: PathReader = readPathFromShell;
-
-const getFreshPath = async (cwd?: string): Promise<string> => {
-  if (cachedPath !== null) return cachedPath;
-  if (pathRefreshPromise) return pathRefreshPromise;
-  pathRefreshPromise = (async () => {
-    const freshPath = await pathReader(cwd);
-    cachedPath = freshPath ?? process.env.PATH ?? "";
-    process.env.PATH = cachedPath;
-    return cachedPath;
-  })();
-  try {
-    return await pathRefreshPromise;
-  } finally {
-    pathRefreshPromise = null;
-  }
-};
-
-export const resetPathCacheForTests = (): void => {
-  cachedPath = null;
-  pathRefreshPromise = null;
-  pathReader = readPathFromShell;
-};
-
-export const setPathReaderForTests = (reader: PathReader): void => {
-  cachedPath = null;
-  pathRefreshPromise = null;
-  pathReader = reader;
-};
-
-const buildSpawnEnv = async (
-  cwd: string | undefined,
-  overrides?: Record<string, string>,
-): Promise<NodeJS.ProcessEnv> => {
-  const freshPath = await getFreshPath(cwd);
-  const baseEnv: NodeJS.ProcessEnv = { ...process.env, PATH: freshPath };
-  return overrides ? { ...baseEnv, ...overrides } : baseEnv;
-};
 
 export class ServiceProcess {
   readonly config: ServiceConfig;
   private readonly detached = SHOULD_DETACH_PROCESS_GROUP;
   private readonly workingDir: string;
+  private readonly launchAdapter: LaunchInstructionExecutionAdapter;
   private state: ServiceState = "STOPPED";
-  private process: Bun.Subprocess<"ignore", "pipe", "pipe"> | null = null;
+  private launchHandle: LaunchExecutionHandle | null = null;
   private subscribers: Set<ServiceSubscriber> = new Set();
   private lastExitCode: number | null = null;
   private lastSignal: string | null = null;
@@ -101,12 +30,11 @@ export class ServiceProcess {
   private command: string[] = [];
   private startedAt: string | null = null;
   private identityVerified = false;
-  private stdoutRemainder = "";
-  private stderrRemainder = "";
 
-  constructor(config: ServiceConfig) {
+  constructor(config: ServiceConfig, launchAdapter = new LaunchInstructionExecutionAdapter()) {
     this.config = config;
     this.workingDir = resolveRuntimeWorkingDir(config.working_dir);
+    this.launchAdapter = launchAdapter;
   }
 
   subscribe(handler: ServiceSubscriber): () => void {
@@ -127,11 +55,11 @@ export class ServiceProcess {
   }
 
   getPid(): number | null {
-    return this.process?.pid ?? null;
+    return this.launchHandle?.pid ?? null;
   }
 
   getPidInfo(): ServicePid | null {
-    const pid = this.process?.pid;
+    const pid = this.launchHandle?.pid;
     if (!pid || !this.startedAt || this.command.length === 0) return null;
     return {
       name: this.config.name,
@@ -144,7 +72,7 @@ export class ServiceProcess {
   }
 
   isRunning(): boolean {
-    return this.process !== null;
+    return this.launchHandle !== null;
   }
 
   async start(): Promise<void> {
@@ -157,166 +85,74 @@ export class ServiceProcess {
 
     const argv = this.config.command;
     this.command = [...argv];
-
-    try {
-      const env = await buildSpawnEnv(this.workingDir, this.config.env);
-      this.process = Bun.spawn({
-        cmd: argv,
-        cwd: this.workingDir,
-        env,
+    this.launchHandle = await this.launchAdapter.start(
+      {
+        argv,
+        workingDir: this.workingDir,
+        env: this.config.env,
         detached: this.detached,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-    } catch (error) {
-      this.lastExitCode = 1;
-      this.lastSignal = null;
-      this.setState("FAILED");
-      this.emit({
-        type: "log",
-        entry: { timestamp: timestamp(), line: getErrorMessage(error), stream: "stderr" },
-      });
-      return;
-    }
-
-    const processInfo = await readLiveProcessInfo(this.process.pid);
-    this.startedAt = processInfo?.startedAt ?? timestamp();
-    this.identityVerified = processInfo !== null;
-    this.setState("RUNNING");
-    this.attachStream(this.process.stdout, "stdout");
-    this.attachStream(this.process.stderr, "stderr");
-    this.process.exited
-      .then((code) => {
-        this.lastExitCode = code;
-        this.lastSignal = this.process?.signalCode ?? null;
-        this.process = null;
-        if (this.stopRequested) {
-          this.setState("STOPPED");
-        } else if (code === 0) {
-          this.setState("STOPPED");
-        } else {
-          this.setState("FAILED");
-        }
-        this.emit({ type: "exit", code, signal: this.lastSignal });
-      })
-      .catch((error) => {
-        this.emit({
-          type: "log",
-          entry: { timestamp: timestamp(), line: getErrorMessage(error), stream: "stderr" },
-        });
-        this.setState("FAILED");
-      });
+      },
+      (event) => this.handleLaunchEvent(event),
+    );
   }
 
   async stop(signal: NodeJS.Signals = "SIGINT"): Promise<void> {
-    if (!this.process) {
+    if (!this.launchHandle) {
       this.setState("STOPPED");
       return;
     }
     this.stopRequested = true;
     this.setState("STOPPING");
     try {
-      this.signalProcess(signal);
+      this.launchHandle.signal(signal);
     } catch {
       this.setState("STOPPED");
     }
   }
 
   async forceStop(signal: NodeJS.Signals = "SIGTERM"): Promise<void> {
-    if (!this.process) {
+    if (!this.launchHandle) {
       this.setState("STOPPED");
       return;
     }
     this.stopRequested = true;
     this.setState("STOPPING");
     try {
-      this.signalProcess(signal);
+      this.launchHandle.signal(signal);
     } catch {
       this.setState("STOPPED");
     }
   }
 
-  private signalProcess(signal: NodeJS.Signals): void {
-    const processHandle = this.process;
-    if (!processHandle) return;
-
-    if (this.signalProcessGroup(processHandle.pid, signal)) return;
-    processHandle.kill(signal);
-  }
-
-  private signalProcessGroup(pid: number, signal: NodeJS.Signals): boolean {
-    if (!this.detached) return false;
-    if (!Number.isInteger(pid) || pid <= 0) return false;
-
-    try {
-      process.kill(-pid, signal);
-      return true;
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException | undefined)?.code;
-      if (code === "ESRCH") {
-        return true;
-      }
-      return false;
-    }
-  }
-
-  private attachStream(stream: ReadableStream<Uint8Array> | null, source: "stdout" | "stderr") {
-    if (!stream) return;
-    const reader = stream.getReader();
-    const readLoop = async () => {
-      while (true) {
-        const result = await reader.read();
-        if (result.done) break;
-        const chunk = lineDecoder.decode(result.value);
-        this.appendChunk(source, chunk);
-      }
-      this.flushRemainder(source);
-    };
-    readLoop().catch((error) => {
-      this.emit({
-        type: "log",
-        entry: { timestamp: timestamp(), line: getErrorMessage(error), stream: "stderr" },
-      });
-    });
-  }
-
-  private appendChunk(source: "stdout" | "stderr", chunk: string) {
-    if (source === "stdout") {
-      this.stdoutRemainder += chunk;
-      const { lines, rest } = splitLines(this.stdoutRemainder);
-      this.stdoutRemainder = rest;
-      for (const line of lines) {
-        this.emit({
-          type: "log",
-          entry: { timestamp: timestamp(), line, stream: source },
-        });
-      }
+  private handleLaunchEvent(event: LaunchExecutionEvent): void {
+    if (event.type === "started") {
+      this.startedAt = event.startedAt;
+      this.identityVerified = event.identityVerified;
+      this.setState("RUNNING");
       return;
     }
 
-    this.stderrRemainder += chunk;
-    const { lines, rest } = splitLines(this.stderrRemainder);
-    this.stderrRemainder = rest;
-    for (const line of lines) {
-      this.emit({
-        type: "log",
-        entry: { timestamp: timestamp(), line, stream: source },
-      });
+    if (event.type === "output") {
+      this.emit({ type: "log", entry: event.entry });
+      return;
     }
-  }
 
-  private flushRemainder(source: "stdout" | "stderr") {
-    const remainder = source === "stdout" ? this.stdoutRemainder : this.stderrRemainder;
-    if (remainder.length === 0) return;
-    if (source === "stdout") {
-      this.stdoutRemainder = "";
-    } else {
-      this.stderrRemainder = "";
+    if (event.type === "spawn-failed") {
+      this.lastExitCode = 1;
+      this.lastSignal = null;
+      this.setState("FAILED");
+      return;
     }
-    this.emit({
-      type: "log",
-      entry: { timestamp: timestamp(), line: remainder, stream: source },
-    });
+
+    this.lastExitCode = event.code;
+    this.lastSignal = event.signal;
+    this.launchHandle = null;
+    if (this.stopRequested || event.code === 0) {
+      this.setState("STOPPED");
+    } else {
+      this.setState("FAILED");
+    }
+    this.emit({ type: "exit", code: event.code, signal: event.signal });
   }
 
   private setState(state: ServiceState) {


### PR DESCRIPTION
## Summary
- add a Launch Instruction execution Adapter for Direct Managed Processes
- move PATH refresh, environment assembly, spawning, stream output, exit observation, signaling, and Process Identity evidence collection behind the Adapter
- make PATH refresh Adapter instance state and share one Adapter across a Workspace ServiceManager
- cover spawn success, spawn failure, output, exit, and signal behavior without launching real OS processes

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #10