### PR TITLE
fix: centralize process claim ownership

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -10,8 +10,8 @@ import {
   writeManifest,
 } from "./init";
 import { loadManifest, parseServiceBlock, renderServiceBlock, saveManifest } from "./manifest";
-import { cleanupExistingPids, syncPidFiles } from "./pidfile";
 import { normalizeProcessDefinition } from "./process-definition";
+import { ProcessClaimStore } from "./process-claim";
 import { getTopologicalServiceOrder } from "./service-graph";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
@@ -111,18 +111,12 @@ const setupKeybindings = (
   appConfig: AppConfig | undefined,
   runtime: AppRuntime,
   shutdown: ShutdownController,
+  processClaimStore: ProcessClaimStore,
 ) => {
   let deleteConfirming = false;
   let discoverySelection: DiscoverySelection | null = null;
   let discoveryOpening = false;
   let discoveryApplying = false;
-  const syncPids = async () => {
-    await syncPidFiles(process.cwd(), manager.getServicePids(), {
-      knownServices: manager.getConfigs().map((config) => config.name),
-      logger: (message) => console.error(message),
-    });
-  };
-
   const closeDiscovery = () => {
     discoveryApplying = false;
     discoverySelection = null;
@@ -251,9 +245,12 @@ const setupKeybindings = (
       try {
         const config = parseServiceBlock(toml, dirname(manifestPath));
         const index = manager.getSelectedIndex();
+        const previousName = manager.getSelectedConfig()?.name;
         await manager.updateServiceConfig(index, config);
         await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-        await syncPids();
+        if (previousName && previousName !== config.name) {
+          await processClaimStore.releaseDirectManagedProcessNames([previousName]);
+        }
       } catch (error) {
         controls.setEditError(getErrorMessage(error));
         return;
@@ -285,7 +282,6 @@ const setupKeybindings = (
           normalizeProcessDefinition({ name, command }, { baseDir: dirname(manifestPath) }),
         );
         await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-        await syncPids();
         controls.hideAddOverlay();
         focusManager.setMode("normal");
       } catch (error) {
@@ -366,7 +362,6 @@ const setupKeybindings = (
           }
 
           await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-          await syncPids();
 
           for (const warning of finalized.warnings) {
             console.error(`Discovery warning: ${warning}`);
@@ -387,9 +382,10 @@ const setupKeybindings = (
 
   const handleDeleteConfirm = async (key: KeyEvent) => {
     if (key.name === "y") {
+      const removedName = manager.getSelectedConfig()?.name;
       await manager.removeSelected();
       await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-      await syncPids();
+      if (removedName) await processClaimStore.releaseDirectManagedProcessNames([removedName]);
       deleteConfirming = false;
       controls.hideDeleteConfirm();
       return;
@@ -740,6 +736,7 @@ const mountMainUiSession = (
     appConfig,
     runtime,
     shutdown,
+    new ProcessClaimStore(process.cwd(), { logger: (message) => console.error(message) }),
   );
 
   if (snapshot) {
@@ -767,7 +764,10 @@ const startApp = async (
   runtime: AppRuntime,
 ) => {
   const manifest = await loadManifest(MANIFEST_PATH);
-  const manager = new ServiceManager(manifest.services);
+  const processClaimStore = new ProcessClaimStore(process.cwd(), {
+    logger: (message) => console.error(message),
+  });
+  const manager = new ServiceManager(manifest.services, { processClaimStore });
   const appConfig = manifest.app;
   const manifestPath = resolve(process.cwd(), MANIFEST_PATH);
 
@@ -780,17 +780,6 @@ const startApp = async (
   });
   shutdown.install();
   shutdownRef.current = shutdown;
-
-  const syncCurrentPids = async () => {
-    await syncPidFiles(process.cwd(), manager.getServicePids(), {
-      knownServices: manager.getConfigs().map((config) => config.name),
-      logger: (message) => console.error(message),
-    });
-  };
-
-  manager.onProcessChange(() => {
-    void syncCurrentPids();
-  });
 
   const sessionRef: { current: MainUiSession | null } = {
     current: mountMainUiSession(
@@ -808,10 +797,9 @@ const startApp = async (
 
   void (async () => {
     try {
-      await cleanupExistingPids(process.cwd(), {
-        logger: (message) => console.error(message),
-        knownServices: manifest.services.map((service) => service.name),
-      });
+      await processClaimStore.cleanupStaleDirectManagedProcessClaims(
+        manifest.services.map((service) => service.name),
+      );
       if (runtime.closing || runtime.disposed) return;
 
       await manager.startAll({
@@ -819,7 +807,6 @@ const startApp = async (
       });
       if (runtime.closing || runtime.disposed) return;
 
-      await syncCurrentPids();
       if (runtime.closing || runtime.disposed || !isDockerEnabled(appConfig)) return;
 
       const composePath = await detectComposeFile(process.cwd());

--- a/src/launch-execution.test.ts
+++ b/src/launch-execution.test.ts
@@ -70,7 +70,9 @@ describe("LaunchInstructionExecutionAdapter", () => {
 
     const handle = await adapter.start(
       { argv: ["missing"], workingDir: "/project", env: {} },
-      (event) => events.push(event),
+      (event) => {
+        events.push(event);
+      },
     );
 
     expect(handle).toBeNull();
@@ -99,9 +101,9 @@ describe("LaunchInstructionExecutionAdapter", () => {
       }),
     });
 
-    await adapter.start({ argv: ["bun"], workingDir: "/project", env: {} }, (event) =>
-      events.push(event),
-    );
+    await adapter.start({ argv: ["bun"], workingDir: "/project", env: {} }, (event) => {
+      events.push(event);
+    });
     await flush();
 
     expect(events).toContainEqual({

--- a/src/launch-execution.ts
+++ b/src/launch-execution.ts
@@ -10,6 +10,7 @@ export type LaunchExecutionEvent =
     }
   | { type: "output"; entry: LogEntry }
   | { type: "spawn-failed"; message: string }
+  | { type: "start-rejected"; message: string }
   | { type: "exit"; code: number | null; signal: string | null };
 
 export interface LaunchInstructionInput {
@@ -24,7 +25,7 @@ export interface LaunchExecutionHandle {
   signal: (signal: NodeJS.Signals) => void;
 }
 
-type LaunchEventHandler = (event: LaunchExecutionEvent) => void;
+type LaunchEventHandler = (event: LaunchExecutionEvent) => Promise<void> | void;
 type PathReader = (cwd: string) => Promise<string | null>;
 type ProcessInfoReader = (pid: number) => Promise<LiveProcessInfo | null>;
 type SignalProcessGroup = (pid: number, signal: NodeJS.Signals) => boolean;
@@ -153,8 +154,8 @@ export class LaunchInstructionExecutionAdapter {
       });
     } catch (error) {
       const message = getErrorMessage(error);
-      onEvent({ type: "spawn-failed", message });
-      onEvent({
+      await onEvent({ type: "spawn-failed", message });
+      await onEvent({
         type: "output",
         entry: { timestamp: this.now(), line: message, stream: "stderr" },
       });
@@ -162,12 +163,23 @@ export class LaunchInstructionExecutionAdapter {
     }
 
     const processInfo = await this.processInfoReader(proc.pid);
-    onEvent({
-      type: "started",
-      pid: proc.pid,
-      startedAt: processInfo?.startedAt ?? this.now(),
-      identityVerified: processInfo !== null,
-    });
+    try {
+      await onEvent({
+        type: "started",
+        pid: proc.pid,
+        startedAt: processInfo?.startedAt ?? this.now(),
+        identityVerified: processInfo !== null,
+      });
+    } catch (error) {
+      const message = getErrorMessage(error);
+      proc.kill("SIGTERM");
+      await onEvent({ type: "start-rejected", message });
+      await onEvent({
+        type: "output",
+        entry: { timestamp: this.now(), line: message, stream: "stderr" },
+      });
+      return null;
+    }
 
     this.attachStream(proc.stdout, "stdout", onEvent);
     this.attachStream(proc.stderr, "stderr", onEvent);

--- a/src/process-claim.ts
+++ b/src/process-claim.ts
@@ -1,0 +1,48 @@
+import {
+  cleanupExistingPids,
+  removePidFilesForServices,
+  removeServicePidFiles,
+  syncPidFiles,
+} from "./pidfile";
+import type { ServicePid } from "./types";
+
+export interface ProcessClaimStoreOptions {
+  logger?: (message: string) => void;
+  timeoutMs?: number;
+}
+
+export class ProcessClaimStore {
+  private readonly cwd: string;
+  private readonly logger?: (message: string) => void;
+  private readonly timeoutMs?: number;
+
+  constructor(cwd: string, options: ProcessClaimStoreOptions = {}) {
+    this.cwd = cwd;
+    this.logger = options.logger;
+    this.timeoutMs = options.timeoutMs;
+  }
+
+  async claimDirectManagedProcess(claim: ServicePid): Promise<void> {
+    await syncPidFiles(this.cwd, [claim], {
+      knownServices: [claim.name],
+      logger: this.logger,
+      timeoutMs: this.timeoutMs,
+    });
+  }
+
+  async releaseDirectManagedProcess(claim: ServicePid): Promise<void> {
+    await removeServicePidFiles(this.cwd, [claim]);
+  }
+
+  async releaseDirectManagedProcessNames(names: string[]): Promise<void> {
+    await removePidFilesForServices(this.cwd, names);
+  }
+
+  async cleanupStaleDirectManagedProcessClaims(knownNames: string[]): Promise<void> {
+    await cleanupExistingPids(this.cwd, {
+      knownServices: knownNames,
+      logger: this.logger,
+      timeoutMs: this.timeoutMs,
+    });
+  }
+}

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
+import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager, ServiceManagerError } from "./service-manager";
-import type { ServiceConfig } from "./types";
+import type { ServiceConfig, ServicePid } from "./types";
 
 const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProcessDefinition(input);
 
@@ -269,5 +270,102 @@ describe("ServiceManager", () => {
     expect(manager.getSelectedView()?.restartCount).toBe(0);
 
     await manager.stopAll();
+  });
+
+  test("creates Process Claims before reporting running", async () => {
+    const events: string[] = [];
+    class TestClaims extends ProcessClaimStore {
+      override async claimDirectManagedProcess(claim: ServicePid): Promise<void> {
+        events.push(`claim:${claim.name}`);
+      }
+    }
+
+    const manager = new ServiceManager([service({ name: "api", command: ["bun", "run", "dev"] })], {
+      processClaimStore: new TestClaims(process.cwd()),
+      launchAdapter: new LaunchInstructionExecutionAdapter({
+        now: () => "now",
+        pathReader: async () => process.env.PATH ?? "",
+        processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+        spawner: () => ({
+          pid: 10,
+          stdout: null,
+          stderr: null,
+          exited: new Promise(() => {}),
+          signalCode: null,
+          kill: () => {},
+        }),
+      }),
+    });
+    manager.onProcessChange(() => {
+      if (manager.getSelectedView()?.state === "RUNNING") events.push("running");
+    });
+
+    await manager.startAll();
+
+    expect(events).toEqual(["claim:api", "running"]);
+  });
+
+  test("stops spawned process and reports failed state when Process Claim creation fails", async () => {
+    const killed: NodeJS.Signals[] = [];
+    class FailingClaims extends ProcessClaimStore {
+      override async claimDirectManagedProcess(): Promise<void> {
+        throw new Error("claim failed");
+      }
+    }
+
+    const manager = new ServiceManager([service({ name: "api", command: ["bun", "run", "dev"] })], {
+      processClaimStore: new FailingClaims(process.cwd()),
+      launchAdapter: new LaunchInstructionExecutionAdapter({
+        now: () => "now",
+        pathReader: async () => process.env.PATH ?? "",
+        processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+        spawner: () => ({
+          pid: 11,
+          stdout: null,
+          stderr: null,
+          exited: new Promise(() => {}),
+          signalCode: null,
+          kill: (signal) => killed.push(signal),
+        }),
+      }),
+    });
+
+    await manager.startAll();
+
+    expect(killed).toEqual(["SIGTERM"]);
+    expect(manager.getSelectedView()?.state).toBe("FAILED");
+    expect(manager.getSelectedView()?.log.all().at(-1)?.line).toBe("claim failed");
+  });
+
+  test("releases Process Claims on claim-relevant exit events", async () => {
+    const released: string[] = [];
+    class TestClaims extends ProcessClaimStore {
+      override async claimDirectManagedProcess(): Promise<void> {}
+      override async releaseDirectManagedProcess(claim: ServicePid): Promise<void> {
+        released.push(claim.name);
+      }
+    }
+
+    const manager = new ServiceManager([service({ name: "api", command: ["bun", "run", "dev"] })], {
+      processClaimStore: new TestClaims(process.cwd()),
+      launchAdapter: new LaunchInstructionExecutionAdapter({
+        now: () => "now",
+        pathReader: async () => process.env.PATH ?? "",
+        processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+        spawner: () => ({
+          pid: 12,
+          stdout: null,
+          stderr: null,
+          exited: Promise.resolve(0),
+          signalCode: null,
+          kill: () => {},
+        }),
+      }),
+    });
+
+    await manager.startAll();
+    await waitFor(() => released.length === 1);
+
+    expect(released).toEqual(["api"]);
   });
 });

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -2,6 +2,7 @@ import { DirectManagedProcessCollectionLifecycle } from "./direct-managed-proces
 import { DirectManagedProcessLifecycle } from "./direct-managed-process-lifecycle";
 import { LogBuffer } from "./log-buffer";
 import { LaunchInstructionExecutionAdapter } from "./launch-execution";
+import { ProcessClaimStore } from "./process-claim";
 import { type ServiceEvent, ServiceProcess } from "./service";
 import { ServiceGraphError } from "./service-graph";
 import { StartupDependencyPlanError } from "./startup-dependency-plan";
@@ -22,6 +23,7 @@ export type UpdateCallback = () => void;
 
 export interface ServiceManagerOptions {
   launchAdapter?: LaunchInstructionExecutionAdapter;
+  processClaimStore?: ProcessClaimStore | null;
 }
 
 const LOG_CAPACITY = 2000;
@@ -41,6 +43,7 @@ export class ServiceManager {
   private readonly lifecycles: Map<ServiceProcess, DirectManagedProcessLifecycle> = new Map();
   private readonly collectionLifecycle: DirectManagedProcessCollectionLifecycle;
   private readonly launchAdapter: LaunchInstructionExecutionAdapter;
+  private readonly processClaimStore: ProcessClaimStore | null;
   private restartTicker: ReturnType<typeof setInterval> | null = null;
   private readonly updateCallbacks: Set<UpdateCallback> = new Set();
   private readonly processCallbacks: Set<UpdateCallback> = new Set();
@@ -48,9 +51,12 @@ export class ServiceManager {
 
   constructor(configs: ServiceConfig[], options: ServiceManagerOptions = {}) {
     this.launchAdapter = options.launchAdapter ?? new LaunchInstructionExecutionAdapter();
+    this.processClaimStore = options.processClaimStore ?? null;
     this.collectionLifecycle = new DirectManagedProcessCollectionLifecycle(() => this.getConfigs());
     this.assertValidConfigGraph(configs);
-    this.services = configs.map((config) => new ServiceProcess(config, this.launchAdapter));
+    this.services = configs.map(
+      (config) => new ServiceProcess(config, this.launchAdapter, this.processClaimStore),
+    );
     this.views = this.services.map((service) => ({
       name: service.config.name,
       state: "STOPPED",
@@ -214,7 +220,7 @@ export class ServiceManager {
 
     this.assertValidConfigGraph([...this.getConfigs(), config]);
 
-    const process = new ServiceProcess(config, this.launchAdapter);
+    const process = new ServiceProcess(config, this.launchAdapter, this.processClaimStore);
     this.services.push(process);
     this.views.push({
       name: config.name,
@@ -277,7 +283,7 @@ export class ServiceManager {
     this.clearServiceRuntimeState(oldService);
     this.unsubscribers[index]?.();
 
-    const newProcess = new ServiceProcess(config, this.launchAdapter);
+    const newProcess = new ServiceProcess(config, this.launchAdapter, this.processClaimStore);
     this.services[index] = newProcess;
 
     const view = this.views[index];

--- a/src/service.ts
+++ b/src/service.ts
@@ -4,6 +4,7 @@ import {
   type LaunchExecutionHandle,
 } from "./launch-execution";
 import { resolveRuntimeWorkingDir } from "./process-info";
+import { ProcessClaimStore } from "./process-claim";
 import type { LogEntry, ServiceConfig, ServicePid, ServiceState } from "./types";
 
 export type ServiceEvent =
@@ -21,6 +22,7 @@ export class ServiceProcess {
   private readonly detached = SHOULD_DETACH_PROCESS_GROUP;
   private readonly workingDir: string;
   private readonly launchAdapter: LaunchInstructionExecutionAdapter;
+  private readonly processClaimStore: ProcessClaimStore | null;
   private state: ServiceState = "STOPPED";
   private launchHandle: LaunchExecutionHandle | null = null;
   private subscribers: Set<ServiceSubscriber> = new Set();
@@ -30,11 +32,17 @@ export class ServiceProcess {
   private command: string[] = [];
   private startedAt: string | null = null;
   private identityVerified = false;
+  private activeClaim: ServicePid | null = null;
 
-  constructor(config: ServiceConfig, launchAdapter = new LaunchInstructionExecutionAdapter()) {
+  constructor(
+    config: ServiceConfig,
+    launchAdapter = new LaunchInstructionExecutionAdapter(),
+    processClaimStore: ProcessClaimStore | null = null,
+  ) {
     this.config = config;
     this.workingDir = resolveRuntimeWorkingDir(config.working_dir);
     this.launchAdapter = launchAdapter;
+    this.processClaimStore = processClaimStore;
   }
 
   subscribe(handler: ServiceSubscriber): () => void {
@@ -81,6 +89,7 @@ export class ServiceProcess {
     this.command = [];
     this.startedAt = null;
     this.identityVerified = false;
+    this.activeClaim = null;
     this.setState("STARTING");
 
     const argv = this.config.command;
@@ -136,10 +145,13 @@ export class ServiceProcess {
     }
   }
 
-  private handleLaunchEvent(event: LaunchExecutionEvent): void {
+  private async handleLaunchEvent(event: LaunchExecutionEvent): Promise<void> {
     if (event.type === "started") {
       this.startedAt = event.startedAt;
       this.identityVerified = event.identityVerified;
+      const claim = this.buildPidInfo(event.pid);
+      await this.processClaimStore?.claimDirectManagedProcess(claim);
+      this.activeClaim = claim;
       this.setState("RUNNING");
       return;
     }
@@ -149,7 +161,7 @@ export class ServiceProcess {
       return;
     }
 
-    if (event.type === "spawn-failed") {
+    if (event.type === "spawn-failed" || event.type === "start-rejected") {
       this.lastExitCode = 1;
       this.lastSignal = null;
       this.setState("FAILED");
@@ -158,13 +170,27 @@ export class ServiceProcess {
 
     this.lastExitCode = event.code;
     this.lastSignal = event.signal;
+    const claim = this.activeClaim;
     this.launchHandle = null;
+    this.activeClaim = null;
     if (this.stopRequested || event.code === 0) {
       this.setState("STOPPED");
     } else {
       this.setState("FAILED");
     }
     this.emit({ type: "exit", code: event.code, signal: event.signal });
+    if (claim) void this.processClaimStore?.releaseDirectManagedProcess(claim);
+  }
+
+  private buildPidInfo(pid: number): ServicePid {
+    return {
+      name: this.config.name,
+      pid,
+      command: [...this.command],
+      workingDir: this.workingDir,
+      startedAt: this.startedAt ?? "",
+      identityVerified: this.identityVerified,
+    };
   }
 
   private setState(state: ServiceState) {


### PR DESCRIPTION
## Summary
- add a ProcessClaimStore seam around existing pidfile operations
- create process claims before direct managed processes report RUNNING
- stop spawned processes and report FAILED when claim creation is rejected
- release claims from direct claim-relevant events and removed/renamed services

Closes #12

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build