### PR TITLE
feat: add external runtime visibility seam

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 import { dirname, resolve } from "node:path";
 import { type KeyEvent, createCliRenderer } from "@opentui/core";
-import { DockerManager, detectComposeFile } from "./docker";
+import { createDockerComposeExternalRuntimeAdapter } from "./docker";
+import { ExternalRuntimeVisibilityManager, detectExternalRuntimes } from "./external-runtime";
 import { FocusManager } from "./focus";
 import {
   DiscoverySelection,
@@ -30,7 +31,7 @@ type ShutdownController = {
 type AppRuntime = {
   disposed: boolean;
   closing: boolean;
-  dockerManager: DockerManager | null;
+  externalRuntimeManager: ExternalRuntimeVisibilityManager | null;
   exitCode: number | null;
 };
 
@@ -38,7 +39,7 @@ type MainUiSession = {
   teardown: () => void;
   controls: UiControls;
   focusManager: FocusManager;
-  dockerManager: DockerManager | null;
+  externalRuntimeManager: ExternalRuntimeVisibilityManager | null;
 };
 
 type MainUiSnapshot = {
@@ -105,7 +106,7 @@ const setupKeybindings = (
   renderer: Awaited<ReturnType<typeof createCliRenderer>>,
   manager: ServiceManager,
   focusManager: FocusManager,
-  dockerManager: DockerManager | null,
+  externalRuntimeManager: ExternalRuntimeVisibilityManager | null,
   controls: UiControls,
   manifestPath: string,
   appConfig: AppConfig | undefined,
@@ -215,23 +216,23 @@ const setupKeybindings = (
     }
   };
 
-  const handleNormalDocker = async (key: KeyEvent) => {
-    if (!dockerManager) return;
+  const handleNormalExternalRuntime = async (key: KeyEvent) => {
+    if (!externalRuntimeManager) return;
     switch (key.name) {
       case "s":
-        await dockerManager.startSelected();
+        await externalRuntimeManager.startSelected();
         break;
       case "x":
-        await dockerManager.stopSelected();
+        await externalRuntimeManager.stopSelected();
         break;
       case "r":
-        await dockerManager.restartSelected();
+        await externalRuntimeManager.restartSelected();
         break;
       case "up":
-        dockerManager.moveSelection(-1);
+        externalRuntimeManager.moveSelection(-1);
         break;
       case "down":
-        dockerManager.moveSelection(1);
+        externalRuntimeManager.moveSelection(1);
         break;
       default:
         break;
@@ -460,20 +461,20 @@ const setupKeybindings = (
     }
   };
 
-  const triggerDockerShortcut = async (shortcut: Shortcut): Promise<void> => {
-    if (!dockerManager) return;
+  const triggerExternalRuntimeShortcut = async (shortcut: Shortcut): Promise<void> => {
+    if (!externalRuntimeManager) return;
     switch (shortcut.label) {
       case "start":
-        await dockerManager.startSelected();
+        await externalRuntimeManager.startSelected();
         return;
       case "stop":
-        await dockerManager.stopSelected();
+        await externalRuntimeManager.stopSelected();
         return;
       case "restart":
-        await dockerManager.restartSelected();
+        await externalRuntimeManager.restartSelected();
         return;
       case "select":
-        dockerManager.moveSelection(1);
+        externalRuntimeManager.moveSelection(1);
         return;
       default:
         return;
@@ -524,7 +525,7 @@ const setupKeybindings = (
     }
 
     if (panel === "docker") {
-      await triggerDockerShortcut(shortcut);
+      await triggerExternalRuntimeShortcut(shortcut);
     }
   };
 
@@ -540,7 +541,7 @@ const setupKeybindings = (
         focusManager.togglePanel("manifest");
         return true;
       case "2":
-        if (dockerManager) {
+        if (externalRuntimeManager) {
           focusManager.togglePanel("docker");
           return true;
         }
@@ -566,12 +567,12 @@ const setupKeybindings = (
       console.error(`Shutdown warning: ${getErrorMessage(error)}`);
     }
 
-    const activeDockerManager = runtime.dockerManager ?? dockerManager;
-    if (activeDockerManager) {
+    const activeExternalRuntimeManager = runtime.externalRuntimeManager ?? externalRuntimeManager;
+    if (activeExternalRuntimeManager) {
       try {
-        await activeDockerManager.destroy();
+        await activeExternalRuntimeManager.destroy();
       } catch (error) {
-        console.error(`Docker cleanup warning: ${getErrorMessage(error)}`);
+        console.error(`External Runtime cleanup warning: ${getErrorMessage(error)}`);
       }
     }
 
@@ -662,7 +663,7 @@ const setupKeybindings = (
       }
 
       if (panel === "docker") {
-        await handleNormalDocker(key);
+        await handleNormalExternalRuntime(key);
         return;
       }
     } catch (error) {
@@ -671,7 +672,7 @@ const setupKeybindings = (
   });
 };
 
-const isDockerEnabled = (appConfig: AppConfig | undefined): boolean =>
+const isExternalRuntimeVisibilityEnabled = (appConfig: AppConfig | undefined): boolean =>
   appConfig?.docker?.enabled ?? true;
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -710,27 +711,27 @@ const mountMainUiSession = (
   manager: ServiceManager,
   manifest: Awaited<ReturnType<typeof loadManifest>>,
   appConfig: AppConfig | undefined,
-  dockerManager: DockerManager | null,
+  externalRuntimeManager: ExternalRuntimeVisibilityManager | null,
   snapshot?: MainUiSnapshot,
 ): MainUiSession => {
-  const focusManager = new FocusManager(dockerManager !== null);
+  const focusManager = new FocusManager(externalRuntimeManager !== null);
   const { teardown, controls } = buildUi({
     renderer,
     manifest,
     manager,
     focusManager,
-    dockerManager,
+    dockerManager: externalRuntimeManager,
   });
 
   teardownRef.current = teardown;
-  runtime.dockerManager = dockerManager;
+  runtime.externalRuntimeManager = externalRuntimeManager;
 
   renderer.keyInput.removeAllListeners("keypress");
   setupKeybindings(
     renderer,
     manager,
     focusManager,
-    dockerManager,
+    externalRuntimeManager,
     controls,
     manifestPath,
     appConfig,
@@ -745,15 +746,15 @@ const mountMainUiSession = (
     controls.renderAll();
   }
 
-  if (dockerManager && !runtime.closing && !runtime.disposed) {
-    dockerManager.startPolling();
+  if (externalRuntimeManager && !runtime.closing && !runtime.disposed) {
+    externalRuntimeManager.startPolling();
   }
 
   return {
     teardown,
     controls,
     focusManager,
-    dockerManager,
+    externalRuntimeManager,
   };
 };
 
@@ -807,10 +808,14 @@ const startApp = async (
       });
       if (runtime.closing || runtime.disposed) return;
 
-      if (runtime.closing || runtime.disposed || !isDockerEnabled(appConfig)) return;
+      if (runtime.closing || runtime.disposed || !isExternalRuntimeVisibilityEnabled(appConfig)) {
+        return;
+      }
 
-      const composePath = await detectComposeFile(process.cwd());
-      if (runtime.closing || runtime.disposed || !composePath) return;
+      const externalRuntimes = await detectExternalRuntimes(process.cwd(), [
+        createDockerComposeExternalRuntimeAdapter(),
+      ]);
+      if (runtime.closing || runtime.disposed || externalRuntimes.length === 0) return;
 
       while (
         !runtime.closing &&
@@ -821,9 +826,9 @@ const startApp = async (
       }
       if (runtime.closing || runtime.disposed) return;
 
-      const dockerManager = new DockerManager(composePath);
+      const externalRuntimeManager = new ExternalRuntimeVisibilityManager(externalRuntimes);
       if (runtime.closing || runtime.disposed) {
-        await dockerManager.destroy();
+        await externalRuntimeManager.destroy();
         return;
       }
       const snapshot = sessionRef.current ? captureMainUiSnapshot(sessionRef.current) : undefined;
@@ -838,7 +843,7 @@ const startApp = async (
         manager,
         manifest,
         appConfig,
-        dockerManager,
+        externalRuntimeManager,
         snapshot,
       );
     } catch (error) {
@@ -916,7 +921,7 @@ export const run = async () => {
   const runtime: AppRuntime = {
     disposed: false,
     closing: false,
-    dockerManager: null,
+    externalRuntimeManager: null,
     exitCode: null,
   };
 
@@ -989,13 +994,13 @@ export const run = async () => {
       runtime.closing = true;
 
       const finishCleanup = async () => {
-        if (runtime.dockerManager) {
+        if (runtime.externalRuntimeManager) {
           try {
-            await runtime.dockerManager.destroy();
+            await runtime.externalRuntimeManager.destroy();
           } catch (error) {
-            console.error(`Docker cleanup warning: ${getErrorMessage(error)}`);
+            console.error(`External Runtime cleanup warning: ${getErrorMessage(error)}`);
           } finally {
-            runtime.dockerManager = null;
+            runtime.externalRuntimeManager = null;
           }
         }
 

--- a/src/docker.test.ts
+++ b/src/docker.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { getStableDockerServiceNames } from "./docker";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createDockerComposeExternalRuntimeAdapter, getStableDockerServiceNames } from "./docker";
 
 describe("getStableDockerServiceNames", () => {
   test("sorts docker service names alphabetically and appends discovered extras", () => {
@@ -17,5 +20,21 @@ describe("getStableDockerServiceNames", () => {
       "db",
       "worker",
     ]);
+  });
+});
+
+describe("createDockerComposeExternalRuntimeAdapter", () => {
+  test("detects Docker Compose as an External Runtime for a Project", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-compose-"));
+    try {
+      await writeFile(join(dir, "compose.yml"), "services:\n  db:\n    image: postgres\n");
+
+      const runtime = await createDockerComposeExternalRuntimeAdapter().detect(dir);
+
+      expect(runtime?.id).toBe("docker-compose");
+      expect(runtime?.name).toBe("Docker Compose");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -1,7 +1,12 @@
 import { resolve } from "node:path";
+import type {
+  ExternalRuntime,
+  ExternalRuntimeAdapter,
+  ExternalRuntimeOutputStream,
+} from "./external-runtime";
 import { LogBuffer } from "./log-buffer";
 import { fileExists } from "./shared";
-import type { DockerService, DockerServiceState } from "./types";
+import type { DockerService, DockerServiceState, ExternalManagedProcess, LogEntry } from "./types";
 
 const COMPOSE_FILES = ["compose.yml", "compose.yaml", "docker-compose.yml", "docker-compose.yaml"];
 
@@ -126,6 +131,183 @@ interface DockerPsEntry {
   State?: string;
   Status?: string;
   Ports?: string;
+}
+
+export const createDockerComposeExternalRuntimeAdapter = (): ExternalRuntimeAdapter => ({
+  id: "docker-compose",
+  name: "Docker Compose",
+  detect: async (cwd) => {
+    const composePath = await detectComposeFile(cwd);
+    return composePath ? new DockerComposeExternalRuntime(composePath) : null;
+  },
+});
+
+class DockerComposeExternalRuntime implements ExternalRuntime {
+  readonly id = "docker-compose";
+  readonly name = "Docker Compose";
+  private readonly composePath: string;
+  private readonly cwd: string;
+
+  constructor(composePath: string) {
+    this.composePath = composePath;
+    this.cwd = resolve(composePath, "..");
+  }
+
+  async snapshot(): Promise<ExternalManagedProcess[]> {
+    let configServices: string[] = [];
+    try {
+      const configProc = Bun.spawn({
+        cmd: ["docker", "compose", "-f", this.composePath, "config", "--services"],
+        cwd: this.cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const configOutput = await new Response(configProc.stdout).text();
+      const exitCode = await configProc.exited;
+      if (exitCode === 0) {
+        configServices = splitLines(configOutput);
+      }
+    } catch {
+      // ignore config errors
+    }
+
+    const proc = Bun.spawn({
+      cmd: ["docker", "compose", "-f", this.composePath, "ps", "--format", "json", "-a"],
+      cwd: this.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    const entries = parsePsOutput(output);
+    const entriesByService = new Map<string, DockerPsEntry[]>();
+    const entryOrder: string[] = [];
+
+    for (const entry of entries) {
+      const name = entry.Service ?? entry.Name ?? "unknown";
+      const list = entriesByService.get(name);
+      if (list) {
+        list.push(entry);
+      } else {
+        entriesByService.set(name, [entry]);
+        entryOrder.push(name);
+      }
+    }
+
+    return getStableDockerServiceNames(configServices, entryOrder).map((name) => {
+      const list = entriesByService.get(name) ?? [];
+      if (list.length === 0) {
+        return {
+          runtimeId: this.id,
+          runtimeName: this.name,
+          name,
+          state: "created",
+          status: "",
+          ports: "",
+        };
+      }
+
+      const state = pickAggregateState(list);
+      const representative =
+        list.find((entry) => parseDockerState(entry.State ?? "unknown") === state) ?? list[0];
+
+      return {
+        runtimeId: this.id,
+        runtimeName: this.name,
+        name,
+        state,
+        status: representative?.Status ?? "",
+        ports: representative?.Ports ?? "",
+      };
+    });
+  }
+
+  async start(name: string): Promise<void> {
+    await this.runCompose(["up", "-d", name]);
+  }
+
+  async stop(name: string): Promise<void> {
+    await this.runCompose(["stop", name]);
+  }
+
+  async restart(name: string): Promise<void> {
+    const exitCode = await this.runCompose(["restart", name]);
+    if (exitCode !== 0) {
+      await this.runCompose(["up", "-d", name]);
+    }
+  }
+
+  streamOutput(
+    name: string,
+    onOutput: (entry: LogEntry) => void,
+  ): ExternalRuntimeOutputStream | null {
+    try {
+      const proc = Bun.spawn({
+        cmd: ["docker", "compose", "-f", this.composePath, "logs", "-f", "--tail=200", name],
+        cwd: this.cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      this.readStream(proc.stdout, onOutput, "stdout");
+      this.readStream(proc.stderr, onOutput, "stderr");
+      return {
+        stop: () => {
+          try {
+            proc.kill("SIGTERM");
+          } catch {
+            // already dead
+          }
+        },
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  async destroy(): Promise<void> {}
+
+  private async runCompose(args: string[]): Promise<number> {
+    const proc = Bun.spawn({
+      cmd: ["docker", "compose", "-f", this.composePath, ...args],
+      cwd: this.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await proc.exited;
+  }
+
+  private readStream(
+    stream: ReadableStream<Uint8Array> | null,
+    onOutput: (entry: LogEntry) => void,
+    source: "stdout" | "stderr",
+  ): void {
+    if (!stream) return;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let remainder = "";
+
+    const readLoop = async () => {
+      while (true) {
+        const result = await reader.read();
+        if (result.done) break;
+        const chunk = decoder.decode(result.value);
+        remainder += chunk;
+        const parts = remainder.split(/\r?\n/);
+        remainder = parts.pop() ?? "";
+        for (const line of parts) {
+          onOutput({ timestamp: new Date().toISOString(), line, stream: source });
+        }
+      }
+      if (remainder) {
+        onOutput({ timestamp: new Date().toISOString(), line: remainder, stream: source });
+      }
+    };
+
+    readLoop().catch(() => {});
+  }
 }
 
 export class DockerManager {

--- a/src/external-runtime.test.ts
+++ b/src/external-runtime.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ExternalRuntimeVisibilityManager,
+  detectExternalRuntimes,
+  type ExternalRuntime,
+  type ExternalRuntimeAdapter,
+} from "./external-runtime";
+import type { ExternalManagedProcess, LogEntry } from "./types";
+
+const process = (runtimeId: string, name: string): ExternalManagedProcess => ({
+  runtimeId,
+  runtimeName: runtimeId,
+  name,
+  state: "running",
+  status: "Up",
+  ports: "",
+});
+
+describe("detectExternalRuntimes", () => {
+  test("asks each External Runtime Adapter whether it is available for the Project", async () => {
+    const asked: string[] = [];
+    const availableRuntime = runtime("docker", [process("docker", "db")]);
+    const adapters: ExternalRuntimeAdapter[] = [
+      {
+        id: "docker",
+        name: "Docker Compose",
+        detect: async (cwd) => {
+          asked.push(`docker:${cwd}`);
+          return availableRuntime;
+        },
+      },
+      {
+        id: "other",
+        name: "Other Runtime",
+        detect: async (cwd) => {
+          asked.push(`other:${cwd}`);
+          return null;
+        },
+      },
+    ];
+
+    const detected = await detectExternalRuntimes("/project", adapters);
+
+    expect(asked).toEqual(["docker:/project", "other:/project"]);
+    expect(detected).toEqual([availableRuntime]);
+  });
+});
+
+describe("ExternalRuntimeVisibilityManager", () => {
+  test("builds a Workspace snapshot from multiple External Runtimes", async () => {
+    const manager = new ExternalRuntimeVisibilityManager([
+      runtime("docker", [process("docker", "db")]),
+      runtime("podman", [process("podman", "cache")]),
+    ]);
+
+    await manager.refresh();
+
+    expect(manager.getProcesses().map((entry) => `${entry.runtimeId}:${entry.name}`)).toEqual([
+      "docker:db",
+      "podman:cache",
+    ]);
+  });
+
+  test("keeps available External Runtime snapshots when another runtime fails", async () => {
+    const manager = new ExternalRuntimeVisibilityManager([
+      runtime("docker", [process("docker", "db")]),
+      {
+        ...runtime("podman", []),
+        snapshot: async () => {
+          throw new Error("runtime unavailable");
+        },
+      },
+    ]);
+
+    await manager.refresh();
+
+    expect(manager.getProcesses().map((entry) => `${entry.runtimeId}:${entry.name}`)).toEqual([
+      "docker:db",
+    ]);
+  });
+
+  test("forwards selected lifecycle actions to the owning External Runtime", async () => {
+    const actions: string[] = [];
+    const manager = new ExternalRuntimeVisibilityManager([
+      runtime("docker", [process("docker", "db")], actions),
+      runtime("podman", [process("podman", "cache")], actions),
+    ]);
+    await manager.refresh();
+    manager.selectIndex(1);
+
+    await manager.restartSelected();
+
+    expect(actions).toEqual(["podman:restart:cache"]);
+  });
+});
+
+const runtime = (
+  id: string,
+  processes: ExternalManagedProcess[],
+  actions: string[] = [],
+): ExternalRuntime => ({
+  id,
+  name: id,
+  snapshot: async () => processes,
+  start: async (name) => {
+    actions.push(`${id}:start:${name}`);
+  },
+  stop: async (name) => {
+    actions.push(`${id}:stop:${name}`);
+  },
+  restart: async (name) => {
+    actions.push(`${id}:restart:${name}`);
+  },
+  streamOutput: (_name: string, _onOutput: (entry: LogEntry) => void) => null,
+  destroy: async () => {},
+});

--- a/src/external-runtime.ts
+++ b/src/external-runtime.ts
@@ -1,0 +1,274 @@
+import { LogBuffer } from "./log-buffer";
+import type { ExternalManagedProcess, LogEntry } from "./types";
+
+export type ExternalRuntimeUpdateCallback = () => void;
+
+export interface ExternalRuntimeOutputStream {
+  stop: () => void;
+}
+
+export interface ExternalRuntime {
+  id: string;
+  name: string;
+  snapshot: () => Promise<ExternalManagedProcess[]>;
+  start: (name: string) => Promise<void>;
+  stop: (name: string) => Promise<void>;
+  restart: (name: string) => Promise<void>;
+  streamOutput: (
+    name: string,
+    onOutput: (entry: LogEntry) => void,
+  ) => ExternalRuntimeOutputStream | null;
+  destroy: () => Promise<void>;
+}
+
+export interface ExternalRuntimeAdapter {
+  id: string;
+  name: string;
+  detect: (cwd: string) => Promise<ExternalRuntime | null>;
+}
+
+const LOG_CAPACITY = 2000;
+
+export const detectExternalRuntimes = async (
+  cwd: string,
+  adapters: ExternalRuntimeAdapter[],
+): Promise<ExternalRuntime[]> => {
+  const runtimes: ExternalRuntime[] = [];
+  for (const adapter of adapters) {
+    const runtime = await adapter.detect(cwd);
+    if (runtime) runtimes.push(runtime);
+  }
+  return runtimes;
+};
+
+export class ExternalRuntimeVisibilityManager {
+  private readonly runtimes: ExternalRuntime[];
+  private processes: ExternalManagedProcess[] = [];
+  private selectedIndex = 0;
+  private readonly logs: Map<string, LogBuffer> = new Map();
+  private readonly updateCallbacks: Set<ExternalRuntimeUpdateCallback> = new Set();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private refreshing = false;
+  private activeOutputStream: ExternalRuntimeOutputStream | null = null;
+  private activeOutputKey: string | null = null;
+
+  constructor(runtimes: ExternalRuntime[]) {
+    this.runtimes = runtimes;
+  }
+
+  onUpdate(callback: ExternalRuntimeUpdateCallback): () => void {
+    this.updateCallbacks.add(callback);
+    return () => this.updateCallbacks.delete(callback);
+  }
+
+  getProcesses(): ExternalManagedProcess[] {
+    return [...this.processes];
+  }
+
+  getServices(): ExternalManagedProcess[] {
+    return this.getProcesses();
+  }
+
+  getSelectedIndex(): number {
+    return this.selectedIndex;
+  }
+
+  setSelectedIndex(index: number): void {
+    const max = Math.max(0, this.processes.length - 1);
+    const next = Math.min(Math.max(index, 0), max);
+    if (next === this.selectedIndex) return;
+    this.selectedIndex = next;
+    this.notify();
+  }
+
+  moveSelection(delta: number): void {
+    this.selectIndex(this.selectedIndex + delta);
+  }
+
+  selectIndex(index: number): void {
+    this.setSelectedIndex(index);
+    const selected = this.getSelectedProcess();
+    const selectedKey = selected ? processKey(selected) : null;
+    if (selected && selectedKey !== this.activeOutputKey) {
+      this.streamOutput(selected);
+    }
+  }
+
+  getSelectedProcess(): ExternalManagedProcess | null {
+    return this.processes[this.selectedIndex] ?? null;
+  }
+
+  getSelectedService(): ExternalManagedProcess | null {
+    return this.getSelectedProcess();
+  }
+
+  getLogBuffer(name: string): LogBuffer {
+    let buffer = this.logs.get(name);
+    if (!buffer) {
+      buffer = new LogBuffer(LOG_CAPACITY);
+      this.logs.set(name, buffer);
+    }
+    return buffer;
+  }
+
+  getSelectedLogBuffer(): LogBuffer | null {
+    const process = this.getSelectedProcess();
+    if (!process) return null;
+    return this.getLogBuffer(processKey(process));
+  }
+
+  getActiveLogBuffer(): LogBuffer | null {
+    if (!this.activeOutputKey) return null;
+    return this.getLogBuffer(this.activeOutputKey);
+  }
+
+  async refresh(): Promise<void> {
+    if (this.refreshing) return;
+    this.refreshing = true;
+
+    try {
+      const previousProcess = this.getSelectedProcess();
+      const previousKey = previousProcess ? processKey(previousProcess) : null;
+      const snapshots = await Promise.all(
+        this.runtimes.map(async (runtime) => {
+          try {
+            return await runtime.snapshot();
+          } catch {
+            return [];
+          }
+        }),
+      );
+      this.processes = snapshots.flat();
+
+      if (previousKey !== null) {
+        const restoredIndex = this.processes.findIndex(
+          (process) => processKey(process) === previousKey,
+        );
+        this.selectedIndex = restoredIndex >= 0 ? restoredIndex : 0;
+      }
+
+      const maxIndex = Math.max(0, this.processes.length - 1);
+      if (this.selectedIndex > maxIndex) {
+        this.selectedIndex = maxIndex;
+      }
+
+      const selected = this.getSelectedProcess();
+      const selectedKey = selected ? processKey(selected) : null;
+      if (selected && this.activeOutputKey !== selectedKey) {
+        this.streamOutput(selected);
+      }
+
+      this.notify();
+    } finally {
+      this.refreshing = false;
+    }
+  }
+
+  async start(name: string): Promise<void> {
+    await this.withProcess(name, (runtime, process) => runtime.start(process.name));
+    await this.refresh();
+  }
+
+  async stop(name: string): Promise<void> {
+    await this.withProcess(name, (runtime, process) => runtime.stop(process.name));
+    await this.refresh();
+  }
+
+  async restart(name: string): Promise<void> {
+    await this.withProcess(name, (runtime, process) => runtime.restart(process.name));
+    await this.refresh();
+  }
+
+  async startSelected(): Promise<void> {
+    const process = this.getSelectedProcess();
+    if (!process) return;
+    await this.start(processKey(process));
+    this.streamSelectedLogs();
+  }
+
+  async stopSelected(): Promise<void> {
+    const process = this.getSelectedProcess();
+    if (!process) return;
+    await this.stop(processKey(process));
+    this.streamSelectedLogs();
+  }
+
+  async restartSelected(): Promise<void> {
+    const process = this.getSelectedProcess();
+    if (!process) return;
+    await this.restart(processKey(process));
+    this.streamSelectedLogs();
+  }
+
+  streamSelectedLogs(): void {
+    const process = this.getSelectedProcess();
+    if (!process) return;
+    this.streamOutput(process);
+  }
+
+  stopLogStream(): void {
+    if (!this.activeOutputStream) return;
+    this.activeOutputStream.stop();
+    this.activeOutputStream = null;
+    this.activeOutputKey = null;
+  }
+
+  startPolling(intervalMs = 3000): void {
+    this.stopPolling();
+    this.refresh();
+    this.pollTimer = setInterval(() => this.refresh(), intervalMs);
+  }
+
+  stopPolling(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.stopPolling();
+    this.stopLogStream();
+    await Promise.all(this.runtimes.map((runtime) => runtime.destroy()));
+  }
+
+  private streamOutput(process: ExternalManagedProcess): void {
+    this.stopLogStream();
+    const key = processKey(process);
+    const buffer = this.getLogBuffer(key);
+    buffer.clear();
+    this.notify();
+
+    const runtime = this.runtimeFor(process.runtimeId);
+    const stream = runtime.streamOutput(process.name, (entry) => {
+      buffer.add(entry);
+      this.notify();
+    });
+    this.activeOutputStream = stream;
+    this.activeOutputKey = stream ? key : null;
+  }
+
+  private async withProcess(
+    key: string,
+    action: (runtime: ExternalRuntime, process: ExternalManagedProcess) => Promise<void>,
+  ): Promise<void> {
+    const process = this.processes.find((candidate) => processKey(candidate) === key);
+    if (!process) return;
+    await action(this.runtimeFor(process.runtimeId), process);
+  }
+
+  private runtimeFor(runtimeId: string): ExternalRuntime {
+    const runtime = this.runtimes.find((candidate) => candidate.id === runtimeId);
+    if (!runtime) throw new Error(`Unknown External Runtime: ${runtimeId}`);
+    return runtime;
+  }
+
+  private notify(): void {
+    for (const callback of this.updateCallbacks) {
+      callback();
+    }
+  }
+}
+
+const processKey = (process: ExternalManagedProcess): string =>
+  `${process.runtimeId}:${process.name}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,17 @@ export interface DockerService {
   ports: string;
 }
 
+export type ExternalManagedProcessState = DockerServiceState;
+
+export interface ExternalManagedProcess {
+  runtimeId: string;
+  runtimeName: string;
+  name: string;
+  state: ExternalManagedProcessState;
+  status: string;
+  ports: string;
+}
+
 export interface Shortcut {
   key: string;
   label: string;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -9,11 +9,11 @@ import {
   TextareaRenderable,
 } from "@opentui/core";
 import type { DiscoverySelection, SelectionItem } from "./discovery";
-import type { DockerManager } from "./docker";
+import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import type { FocusManager } from "./focus";
 import type { ServiceManager, ServiceView } from "./service-manager";
 import { formatCommandSpec } from "./shared";
-import type { DockerService, LogEntry, Manifest, PanelId, Shortcut } from "./types";
+import type { ExternalManagedProcess, LogEntry, Manifest, PanelId, Shortcut } from "./types";
 
 interface Palette {
   active: string;
@@ -120,7 +120,7 @@ const stateColor = (state: ServiceView["state"], palette: Palette): string => {
   }
 };
 
-const dockerStateColor = (state: DockerService["state"], palette: Palette): string => {
+const dockerStateColor = (state: ExternalManagedProcess["state"], palette: Palette): string => {
   switch (state) {
     case "running":
       return palette.green;
@@ -139,7 +139,7 @@ const dockerStateColor = (state: DockerService["state"], palette: Palette): stri
 
 const formatState = (state: ServiceView["state"]) => state.padEnd(8, " ");
 
-const formatDockerState = (state: DockerService["state"]) => state.padEnd(10, " ");
+const formatDockerState = (state: ExternalManagedProcess["state"]) => state.padEnd(10, " ");
 
 const formatExit = (exit: number | null) => {
   if (exit === null) return "--";
@@ -183,7 +183,11 @@ const formatManifestLine = (view: ServiceView, selected: boolean, rowWidth: numb
   return `${prefix} ${status} ${name}`.slice(0, rowWidth);
 };
 
-const formatDockerLine = (service: DockerService, selected: boolean, rowWidth: number): string => {
+const formatDockerLine = (
+  service: ExternalManagedProcess,
+  selected: boolean,
+  rowWidth: number,
+): string => {
   if (rowWidth <= 0) return "";
   const prefix = selected ? ">" : " ";
   const status = formatDockerState(service.state);
@@ -260,7 +264,7 @@ export interface UiOptions {
   manifest: Manifest;
   manager: ServiceManager;
   focusManager: FocusManager;
-  dockerManager: DockerManager | null;
+  dockerManager: ExternalRuntimeVisibilityManager | null;
 }
 
 export interface UiControls {
@@ -468,7 +472,7 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
   let dockerList: ScrollBoxRenderable | null = null;
 
   if (hasDocker) {
-    const panelParts = createPanel("Docker", "docker");
+    const panelParts = createPanel("External", "docker");
     dockerPanel = panelParts.panel;
     dockerPanelTitle = panelParts.titleText;
     dockerPanelMeta = panelParts.metaText;
@@ -600,7 +604,7 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
     follow: "tail",
     discover: "scan",
     "manifest panel": "manifest",
-    "docker panel": "docker",
+    "docker panel": "external",
     "logs panel": "logs",
     "all panels": "all",
   };
@@ -762,21 +766,23 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
     ];
 
     if (hasDocker && dockerManager) {
-      const dockerServices = dockerManager.getServices();
-      const dockerRunning = dockerServices.filter((service) => service.state === "running").length;
-      const dockerStopped = dockerServices.filter(
+      const externalProcesses = dockerManager.getProcesses();
+      const externalRunning = externalProcesses.filter(
+        (process) => process.state === "running",
+      ).length;
+      const externalStopped = externalProcesses.filter(
         (service) => service.state === "dead" || service.state === "exited",
       ).length;
 
       segments.push({
-        content: `${dockerRunning}/${dockerServices.length} docker`,
-        fg: summaryColor(dockerRunning, dockerServices.length, dockerStopped),
+        content: `${externalRunning}/${externalProcesses.length} external`,
+        fg: summaryColor(externalRunning, externalProcesses.length, externalStopped),
         panel: "docker",
       });
 
       segments.push({
-        content: `${dockerStopped} stopped`,
-        fg: dockerStopped > 0 ? palette.red : palette.muted,
+        content: `${externalStopped} stopped`,
+        fg: externalStopped > 0 ? palette.red : palette.muted,
         panel: "docker",
       });
 
@@ -868,7 +874,7 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
     const selectedDocker = dockerManager?.getSelectedService() ?? null;
     const activeLogName =
       logSource === "docker"
-        ? (selectedDocker?.name ?? "docker")
+        ? (selectedDocker?.name ?? "external")
         : (selectedManifest?.name ?? "service");
     const tailState = logsFollowTail ? "tail:on" : "tail:paused";
     const manifestState = selectedManifest?.state.toLowerCase() ?? "none";
@@ -882,7 +888,7 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
         fg: selectedManifest ? stateColor(selectedManifest.state, palette) : palette.muted,
       },
       {
-        content: `docker:${selectedDocker?.name ?? "-"} (${dockerState})`,
+        content: `external:${selectedDocker?.name ?? "-"} (${dockerState})`,
         fg: selectedDocker ? dockerStateColor(selectedDocker.state, palette) : palette.muted,
       },
       {
@@ -1726,7 +1732,7 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
   const rebuildDockerList = () => {
     if (!dockerManager || !dockerList || !dockerPanelMeta) return;
 
-    const services = dockerManager.getServices();
+    const services = dockerManager.getProcesses();
     const selectedIdx = dockerManager.getSelectedIndex();
     dockerLines = syncRows(dockerList, dockerLines, services.length, "docker");
 
@@ -1900,7 +1906,7 @@ export const buildUi = (opts: UiOptions): { teardown: () => void; controls: UiCo
     }
 
     if (dockerPanel && dockerPanelTitle) {
-      dockerPanelTitle.content = "Docker";
+      dockerPanelTitle.content = "External";
       dockerPanelTitle.fg = panelTitleColor("docker");
       dockerPanel.backgroundColor = panelBackgroundColor("docker");
     }


### PR DESCRIPTION
## Summary
- add a generic External Runtime Visibility manager and detection flow
- support multiple External Runtime adapters in one workspace snapshot
- add Docker Compose as the first External Runtime adapter
- route app startup through generic External Runtime Detection
- update workspace-facing UI copy toward External Managed Process language

Closes #13

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build