### PR TITLE
feat: support cross-runtime startup dependencies

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,7 @@ import { getTopologicalServiceOrder } from "./service-graph";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
 import { createShutdownHandler } from "./shutdown";
-import type { AppConfig, PanelId, Shortcut } from "./types";
+import type { AppConfig, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
 
 const MANIFEST_PATH = "stasium.toml";
@@ -40,12 +40,6 @@ type MainUiSession = {
   controls: UiControls;
   focusManager: FocusManager;
   externalRuntimeManager: ExternalRuntimeVisibilityManager | null;
-};
-
-type MainUiSnapshot = {
-  activePanel: PanelId;
-  visiblePanels: PanelId[];
-  logsFollowTail: boolean;
 };
 
 const setupInitSelectionKeybindings = (
@@ -675,33 +669,6 @@ const setupKeybindings = (
 const isExternalRuntimeVisibilityEnabled = (appConfig: AppConfig | undefined): boolean =>
   appConfig?.docker?.enabled ?? true;
 
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-const captureMainUiSnapshot = (session: MainUiSession): MainUiSnapshot => ({
-  activePanel: session.focusManager.getActivePanel(),
-  visiblePanels: session.focusManager.getVisiblePanels(),
-  logsFollowTail: session.controls.getLogsFollowTail(),
-});
-
-const restoreMainUiSnapshot = (
-  focusManager: FocusManager,
-  controls: UiControls,
-  snapshot: MainUiSnapshot,
-): void => {
-  for (const panel of focusManager.getVisiblePanels()) {
-    if (!snapshot.visiblePanels.includes(panel)) {
-      focusManager.togglePanel(panel);
-    }
-  }
-
-  if (focusManager.isPanelVisible(snapshot.activePanel)) {
-    focusManager.setActivePanel(snapshot.activePanel);
-  }
-
-  controls.setLogsFollowTail(snapshot.logsFollowTail);
-  controls.renderAll();
-};
-
 const mountMainUiSession = (
   renderer: Awaited<ReturnType<typeof createCliRenderer>>,
   teardownRef: { current: (() => void) | null },
@@ -712,7 +679,6 @@ const mountMainUiSession = (
   manifest: Awaited<ReturnType<typeof loadManifest>>,
   appConfig: AppConfig | undefined,
   externalRuntimeManager: ExternalRuntimeVisibilityManager | null,
-  snapshot?: MainUiSnapshot,
 ): MainUiSession => {
   const focusManager = new FocusManager(externalRuntimeManager !== null);
   const { teardown, controls } = buildUi({
@@ -740,11 +706,7 @@ const mountMainUiSession = (
     new ProcessClaimStore(process.cwd(), { logger: (message) => console.error(message) }),
   );
 
-  if (snapshot) {
-    restoreMainUiSnapshot(focusManager, controls, snapshot);
-  } else {
-    controls.renderAll();
-  }
+  controls.renderAll();
 
   if (externalRuntimeManager && !runtime.closing && !runtime.disposed) {
     externalRuntimeManager.startPolling();
@@ -768,9 +730,17 @@ const startApp = async (
   const processClaimStore = new ProcessClaimStore(process.cwd(), {
     logger: (message) => console.error(message),
   });
-  const manager = new ServiceManager(manifest.services, { processClaimStore });
   const appConfig = manifest.app;
   const manifestPath = resolve(process.cwd(), MANIFEST_PATH);
+  const externalRuntimes = isExternalRuntimeVisibilityEnabled(appConfig)
+    ? await detectExternalRuntimes(process.cwd(), [createDockerComposeExternalRuntimeAdapter()])
+    : [];
+  const externalRuntimeManager =
+    externalRuntimes.length > 0 ? new ExternalRuntimeVisibilityManager(externalRuntimes) : null;
+  const manager = new ServiceManager(manifest.services, {
+    processClaimStore,
+    externalRuntimeManager,
+  });
 
   shutdownRef.current?.uninstall();
   const shutdown = createShutdownHandler({
@@ -782,19 +752,17 @@ const startApp = async (
   shutdown.install();
   shutdownRef.current = shutdown;
 
-  const sessionRef: { current: MainUiSession | null } = {
-    current: mountMainUiSession(
-      renderer,
-      teardownRef,
-      runtime,
-      shutdown,
-      manifestPath,
-      manager,
-      manifest,
-      appConfig,
-      null,
-    ),
-  };
+  mountMainUiSession(
+    renderer,
+    teardownRef,
+    runtime,
+    shutdown,
+    manifestPath,
+    manager,
+    manifest,
+    appConfig,
+    externalRuntimeManager,
+  );
 
   void (async () => {
     try {
@@ -806,46 +774,6 @@ const startApp = async (
       await manager.startAll({
         shouldCancel: () => runtime.closing || runtime.disposed,
       });
-      if (runtime.closing || runtime.disposed) return;
-
-      if (runtime.closing || runtime.disposed || !isExternalRuntimeVisibilityEnabled(appConfig)) {
-        return;
-      }
-
-      const externalRuntimes = await detectExternalRuntimes(process.cwd(), [
-        createDockerComposeExternalRuntimeAdapter(),
-      ]);
-      if (runtime.closing || runtime.disposed || externalRuntimes.length === 0) return;
-
-      while (
-        !runtime.closing &&
-        !runtime.disposed &&
-        sessionRef.current?.focusManager.getMode() !== "normal"
-      ) {
-        await sleep(50);
-      }
-      if (runtime.closing || runtime.disposed) return;
-
-      const externalRuntimeManager = new ExternalRuntimeVisibilityManager(externalRuntimes);
-      if (runtime.closing || runtime.disposed) {
-        await externalRuntimeManager.destroy();
-        return;
-      }
-      const snapshot = sessionRef.current ? captureMainUiSnapshot(sessionRef.current) : undefined;
-
-      sessionRef.current?.teardown();
-      sessionRef.current = mountMainUiSession(
-        renderer,
-        teardownRef,
-        runtime,
-        shutdown,
-        manifestPath,
-        manager,
-        manifest,
-        appConfig,
-        externalRuntimeManager,
-        snapshot,
-      );
     } catch (error) {
       console.error(getErrorMessage(error));
     }

--- a/src/direct-managed-process-collection.ts
+++ b/src/direct-managed-process-collection.ts
@@ -2,38 +2,47 @@ import { getDependencyClosure, getDependentsClosure } from "./service-graph";
 import { planStartupDependencies } from "./startup-dependency-plan";
 import type { ServiceConfig } from "./types";
 
+export interface DirectManagedProcessCollectionLifecycleOptions {
+  allowExternalDependencies?: boolean;
+}
+
 export class DirectManagedProcessCollectionLifecycle {
   private readonly getConfigs: () => ServiceConfig[];
+  private readonly options: DirectManagedProcessCollectionLifecycleOptions;
 
-  constructor(getConfigs: () => ServiceConfig[]) {
+  constructor(
+    getConfigs: () => ServiceConfig[],
+    options: DirectManagedProcessCollectionLifecycleOptions = {},
+  ) {
     this.getConfigs = getConfigs;
+    this.options = options;
   }
 
   validate(configs: ServiceConfig[]): void {
-    planStartupDependencies(configs);
+    planStartupDependencies(configs, this.options);
   }
 
   startupLayers(): string[][] {
-    return planStartupDependencies(this.getConfigs()).startupLayers;
+    return planStartupDependencies(this.getConfigs(), this.options).startupLayers;
   }
 
   startupOrder(): string[] {
-    return planStartupDependencies(this.getConfigs()).startupOrder;
+    return planStartupDependencies(this.getConfigs(), this.options).startupOrder;
   }
 
   shutdownOrder(): string[] {
-    return planStartupDependencies(this.getConfigs()).shutdownOrder;
+    return planStartupDependencies(this.getConfigs(), this.options).shutdownOrder;
   }
 
   startOrderFor(name: string): string[] {
     const configs = this.getConfigs();
-    const closure = getDependencyClosure(configs, name);
+    const closure = getDependencyClosure(configs, name, this.options);
     return this.startupOrder().filter((processName) => closure.has(processName));
   }
 
   stopOrderFor(name: string): string[] {
     const configs = this.getConfigs();
-    const closure = getDependentsClosure(configs, name);
+    const closure = getDependentsClosure(configs, name, this.options);
     return this.startupOrder()
       .filter((processName) => closure.has(processName))
       .reverse();

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -228,6 +228,10 @@ class DockerComposeExternalRuntime implements ExternalRuntime {
     await this.runCompose(["up", "-d", name]);
   }
 
+  isAvailable(process: ExternalManagedProcess): boolean {
+    return process.state === "running";
+  }
+
   async stop(name: string): Promise<void> {
     await this.runCompose(["stop", name]);
   }

--- a/src/external-runtime.test.ts
+++ b/src/external-runtime.test.ts
@@ -102,6 +102,7 @@ const runtime = (
   id,
   name: id,
   snapshot: async () => processes,
+  isAvailable: (process) => process.state === "running",
   start: async (name) => {
     actions.push(`${id}:start:${name}`);
   },

--- a/src/external-runtime.ts
+++ b/src/external-runtime.ts
@@ -11,7 +11,8 @@ export interface ExternalRuntime {
   id: string;
   name: string;
   snapshot: () => Promise<ExternalManagedProcess[]>;
-  start: (name: string) => Promise<void>;
+  isAvailable: (process: ExternalManagedProcess) => boolean;
+  start?: (name: string) => Promise<void>;
   stop: (name: string) => Promise<void>;
   restart: (name: string) => Promise<void>;
   streamOutput: (
@@ -165,8 +166,29 @@ export class ExternalRuntimeVisibilityManager {
   }
 
   async start(name: string): Promise<void> {
-    await this.withProcess(name, (runtime, process) => runtime.start(process.name));
+    await this.withProcess(name, async (runtime, process) => {
+      await runtime.start?.(process.name);
+    });
     await this.refresh();
+  }
+
+  async ensureProcessAvailable(name: string): Promise<boolean> {
+    await this.refresh();
+    const process = this.findProcess(name);
+    if (!process) return false;
+
+    let runtime = this.runtimeFor(process.runtimeId);
+    if (runtime.isAvailable(process)) return true;
+    if (!runtime.start) return false;
+
+    await runtime.start(process.name);
+    await this.refresh();
+
+    const updated = this.findProcess(name);
+    if (!updated) return false;
+
+    runtime = this.runtimeFor(updated.runtimeId);
+    return runtime.isAvailable(updated);
   }
 
   async stop(name: string): Promise<void> {
@@ -252,9 +274,13 @@ export class ExternalRuntimeVisibilityManager {
     key: string,
     action: (runtime: ExternalRuntime, process: ExternalManagedProcess) => Promise<void>,
   ): Promise<void> {
-    const process = this.processes.find((candidate) => processKey(candidate) === key);
+    const process = this.findProcess(key);
     if (!process) return;
     await action(this.runtimeFor(process.runtimeId), process);
+  }
+
+  private findProcess(name: string): ExternalManagedProcess | null {
+    return this.processes.find((candidate) => matchesProcessName(candidate, name)) ?? null;
   }
 
   private runtimeFor(runtimeId: string): ExternalRuntime {
@@ -272,3 +298,6 @@ export class ExternalRuntimeVisibilityManager {
 
 const processKey = (process: ExternalManagedProcess): string =>
   `${process.runtimeId}:${process.name}`;
+
+const matchesProcessName = (process: ExternalManagedProcess, name: string): boolean =>
+  process.name === name || processKey(process) === name;

--- a/src/service-graph.ts
+++ b/src/service-graph.ts
@@ -1,5 +1,9 @@
 import type { ServiceConfig } from "./types";
 
+export interface ServiceGraphOptions {
+  allowExternalDependencies?: boolean;
+}
+
 export class ServiceGraphError extends Error {
   constructor(message: string) {
     super(message);
@@ -62,12 +66,15 @@ const findCycle = (servicesByName: Map<string, ServiceConfig>): string[] | null 
   return null;
 };
 
-export const validateServiceGraph = (services: ServiceConfig[]): void => {
+export const validateServiceGraph = (
+  services: ServiceConfig[],
+  options: ServiceGraphOptions = {},
+): void => {
   const servicesByName = buildServiceMap(services);
 
   for (const service of services) {
     for (const dependency of dependenciesOf(service)) {
-      if (!servicesByName.has(dependency)) {
+      if (!servicesByName.has(dependency) && !options.allowExternalDependencies) {
         throw new ServiceGraphError(
           `Service "${service.name}" depends on unknown service "${dependency}"`,
         );
@@ -84,8 +91,11 @@ export const validateServiceGraph = (services: ServiceConfig[]): void => {
   }
 };
 
-export const getTopologicalServiceOrder = (services: ServiceConfig[]): string[] => {
-  validateServiceGraph(services);
+export const getTopologicalServiceOrder = (
+  services: ServiceConfig[],
+  options: ServiceGraphOptions = {},
+): string[] => {
+  validateServiceGraph(services, options);
 
   const indegree = new Map<string, number>();
   const dependents = new Map<string, string[]>();
@@ -97,6 +107,7 @@ export const getTopologicalServiceOrder = (services: ServiceConfig[]): string[] 
 
   for (const service of services) {
     for (const dependency of dependenciesOf(service)) {
+      if (!dependents.has(dependency)) continue;
       indegree.set(service.name, (indegree.get(service.name) ?? 0) + 1);
       const list = dependents.get(dependency);
       if (list) {
@@ -131,8 +142,11 @@ export const getTopologicalServiceOrder = (services: ServiceConfig[]): string[] 
   return ordered;
 };
 
-export const getTopologicalServiceLayers = (services: ServiceConfig[]): string[][] => {
-  validateServiceGraph(services);
+export const getTopologicalServiceLayers = (
+  services: ServiceConfig[],
+  options: ServiceGraphOptions = {},
+): string[][] => {
+  validateServiceGraph(services, options);
 
   const indegree = new Map<string, number>();
   const dependents = new Map<string, string[]>();
@@ -144,6 +158,7 @@ export const getTopologicalServiceLayers = (services: ServiceConfig[]): string[]
 
   for (const service of services) {
     for (const dependency of dependenciesOf(service)) {
+      if (!dependents.has(dependency)) continue;
       indegree.set(service.name, (indegree.get(service.name) ?? 0) + 1);
       const list = dependents.get(dependency);
       if (list) {
@@ -182,8 +197,12 @@ export const getTopologicalServiceLayers = (services: ServiceConfig[]): string[]
   return layers;
 };
 
-export const getDependencyClosure = (services: ServiceConfig[], target: string): Set<string> => {
-  validateServiceGraph(services);
+export const getDependencyClosure = (
+  services: ServiceConfig[],
+  target: string,
+  options: ServiceGraphOptions = {},
+): Set<string> => {
+  validateServiceGraph(services, options);
 
   const byName = buildServiceMap(services);
   if (!byName.has(target)) {
@@ -208,8 +227,12 @@ export const getDependencyClosure = (services: ServiceConfig[], target: string):
   return closure;
 };
 
-export const getDependentsClosure = (services: ServiceConfig[], target: string): Set<string> => {
-  validateServiceGraph(services);
+export const getDependentsClosure = (
+  services: ServiceConfig[],
+  target: string,
+  options: ServiceGraphOptions = {},
+): Set<string> => {
+  validateServiceGraph(services, options);
 
   const byName = buildServiceMap(services);
   if (!byName.has(target)) {

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { ExternalRuntimeVisibilityManager, type ExternalRuntime } from "./external-runtime";
 import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
 import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager, ServiceManagerError } from "./service-manager";
-import type { ServiceConfig, ServicePid } from "./types";
+import type { ExternalManagedProcess, LogEntry, ServiceConfig, ServicePid } from "./types";
 
 const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProcessDefinition(input);
 
@@ -37,6 +38,54 @@ const waitFor = async (
   }
   return predicate();
 };
+
+const launchLongRunningPid = (pid: number): LaunchInstructionExecutionAdapter =>
+  new LaunchInstructionExecutionAdapter({
+    now: () => "now",
+    pathReader: async () => process.env.PATH ?? "",
+    processInfoReader: async (nextPid) => ({ pid: nextPid, startedAt: "started", command: null }),
+    spawner: () => ({
+      pid,
+      stdout: null,
+      stderr: null,
+      exited: new Promise(() => {}),
+      signalCode: null,
+      kill: () => {},
+    }),
+  });
+
+const externalProcess = (
+  name: string,
+  state: ExternalManagedProcess["state"],
+): ExternalManagedProcess => ({
+  runtimeId: "docker-compose",
+  runtimeName: "Docker Compose",
+  name,
+  state,
+  status: state,
+  ports: "",
+});
+
+const externalRuntime = (
+  getProcesses: () => ExternalManagedProcess[],
+  actions: string[] = [],
+): ExternalRuntime => ({
+  id: "docker-compose",
+  name: "Docker Compose",
+  snapshot: async () => getProcesses(),
+  isAvailable: (process) => process.state === "running",
+  start: async (name) => {
+    actions.push(`start:${name}`);
+  },
+  stop: async (name) => {
+    actions.push(`stop:${name}`);
+  },
+  restart: async (name) => {
+    actions.push(`restart:${name}`);
+  },
+  streamOutput: (_name: string, _onOutput: (entry: LogEntry) => void) => null,
+  destroy: async () => {},
+});
 
 describe("ServiceManager", () => {
   test("rejects duplicate names when adding services", async () => {
@@ -72,6 +121,68 @@ describe("ServiceManager", () => {
     expect(pids.includes("api")).toBe(true);
 
     await manager.stopAll();
+  });
+
+  test("starts unavailable External Managed Process dependencies before direct processes", async () => {
+    const actions: string[] = [];
+    const claims: string[] = [];
+    class TestClaims extends ProcessClaimStore {
+      override async claimDirectManagedProcess(claim: ServicePid): Promise<void> {
+        claims.push(claim.name);
+      }
+    }
+    let dbState: ExternalManagedProcess["state"] = "exited";
+    const runtime = externalRuntime(() => [externalProcess("db", dbState)], actions);
+    const originalStart = runtime.start!;
+    runtime.start = async (name) => {
+      await originalStart(name);
+      dbState = "running";
+    };
+    const externalRuntimeManager = new ExternalRuntimeVisibilityManager([runtime]);
+    const manager = new ServiceManager(
+      [
+        service({
+          name: "api",
+          command: ["bun", "run", "dev"],
+          depends_on: ["db"],
+        }),
+      ],
+      {
+        externalRuntimeManager,
+        launchAdapter: launchLongRunningPid(20),
+        processClaimStore: new TestClaims(process.cwd()),
+      },
+    );
+
+    await manager.startAll();
+
+    expect(actions).toEqual(["start:db"]);
+    expect(claims).toEqual(["api"]);
+    expect(manager.getSelectedView()?.state).toBe("RUNNING");
+    expect(manager.getServicePids()).toHaveLength(1);
+  });
+
+  test("blocks direct processes when External Managed Process dependencies stay unavailable", async () => {
+    const actions: string[] = [];
+    const externalRuntimeManager = new ExternalRuntimeVisibilityManager([
+      externalRuntime(() => [externalProcess("db", "exited")], actions),
+    ]);
+    const manager = new ServiceManager(
+      [
+        service({
+          name: "api",
+          command: ["bun", "run", "dev"],
+          depends_on: ["db"],
+        }),
+      ],
+      { externalRuntimeManager, launchAdapter: launchLongRunningPid(21) },
+    );
+
+    await manager.startAll();
+
+    expect(actions).toEqual(["start:db"]);
+    expect(manager.getSelectedView()?.state).toBe("BLOCKED");
+    expect(manager.getServicePids()).toHaveLength(0);
   });
 
   test("stops selected dependency and its dependents", async () => {

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -1,5 +1,6 @@
 import { DirectManagedProcessCollectionLifecycle } from "./direct-managed-process-collection";
 import { DirectManagedProcessLifecycle } from "./direct-managed-process-lifecycle";
+import { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { LogBuffer } from "./log-buffer";
 import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { ProcessClaimStore } from "./process-claim";
@@ -24,6 +25,7 @@ export type UpdateCallback = () => void;
 export interface ServiceManagerOptions {
   launchAdapter?: LaunchInstructionExecutionAdapter;
   processClaimStore?: ProcessClaimStore | null;
+  externalRuntimeManager?: ExternalRuntimeVisibilityManager | null;
 }
 
 const LOG_CAPACITY = 2000;
@@ -44,6 +46,7 @@ export class ServiceManager {
   private readonly collectionLifecycle: DirectManagedProcessCollectionLifecycle;
   private readonly launchAdapter: LaunchInstructionExecutionAdapter;
   private readonly processClaimStore: ProcessClaimStore | null;
+  private readonly externalRuntimeManager: ExternalRuntimeVisibilityManager | null;
   private restartTicker: ReturnType<typeof setInterval> | null = null;
   private readonly updateCallbacks: Set<UpdateCallback> = new Set();
   private readonly processCallbacks: Set<UpdateCallback> = new Set();
@@ -52,7 +55,13 @@ export class ServiceManager {
   constructor(configs: ServiceConfig[], options: ServiceManagerOptions = {}) {
     this.launchAdapter = options.launchAdapter ?? new LaunchInstructionExecutionAdapter();
     this.processClaimStore = options.processClaimStore ?? null;
-    this.collectionLifecycle = new DirectManagedProcessCollectionLifecycle(() => this.getConfigs());
+    this.externalRuntimeManager = options.externalRuntimeManager ?? null;
+    this.collectionLifecycle = new DirectManagedProcessCollectionLifecycle(
+      () => this.getConfigs(),
+      {
+        allowExternalDependencies: this.externalRuntimeManager !== null,
+      },
+    );
     this.assertValidConfigGraph(configs);
     this.services = configs.map(
       (config) => new ServiceProcess(config, this.launchAdapter, this.processClaimStore),
@@ -442,7 +451,7 @@ export class ServiceManager {
   }
 
   private async startServiceUnlessBlocked(service: ServiceProcess): Promise<void> {
-    const blockedBy = this.getUnavailableDependencies(service.config);
+    const blockedBy = await this.getUnavailableDependencies(service.config);
     if (blockedBy.length > 0) {
       service.block(
         `Startup blocked by failed Startup Dependency ${blockedBy.map((name) => `"${name}"`).join(", ")}.`,
@@ -453,11 +462,19 @@ export class ServiceManager {
     await this.startService(service);
   }
 
-  private getUnavailableDependencies(config: ServiceConfig): string[] {
-    return config.depends_on.filter((dependency) => {
+  private async getUnavailableDependencies(config: ServiceConfig): Promise<string[]> {
+    const blocked: string[] = [];
+    for (const dependency of config.depends_on) {
       const view = this.views.find((entry) => entry.name === dependency);
-      return view?.state === "FAILED" || view?.state === "BLOCKED";
-    });
+      if (view) {
+        if (view.state === "FAILED" || view.state === "BLOCKED") blocked.push(dependency);
+        continue;
+      }
+
+      const available = await this.externalRuntimeManager?.ensureProcessAvailable(dependency);
+      if (!available) blocked.push(dependency);
+    }
+    return blocked;
   }
 
   private hasServiceName(name: string, exceptIndex: number | null = null): boolean {

--- a/src/startup-dependency-plan.ts
+++ b/src/startup-dependency-plan.ts
@@ -20,6 +20,10 @@ export interface StartupDependencyPlan {
   shutdownOrder: string[];
 }
 
+export interface StartupDependencyPlanOptions {
+  allowExternalDependencies?: boolean;
+}
+
 export class StartupDependencyPlanError extends Error {
   constructor(message: string) {
     super(message);
@@ -46,16 +50,17 @@ const cloneProcessDefinitions = (processDefinitions: ServiceConfig[]): ServiceCo
 
 export const planStartupDependencies = (
   processDefinitions: ServiceConfig[],
+  options: StartupDependencyPlanOptions = {},
 ): StartupDependencyPlan => {
   const cloned = cloneProcessDefinitions(processDefinitions);
 
   try {
-    validateServiceGraph(cloned);
-    const startupOrder = getTopologicalServiceOrder(cloned);
+    validateServiceGraph(cloned, options);
+    const startupOrder = getTopologicalServiceOrder(cloned, options);
     return {
       processDefinitions: cloned,
       startupOrder,
-      startupLayers: getTopologicalServiceLayers(cloned),
+      startupLayers: getTopologicalServiceLayers(cloned, options),
       shutdownOrder: [...startupOrder].reverse(),
     };
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow direct startup dependency planning to reference external dependencies when an External Runtime is configured
- resolve external dependency availability through runtime-specific state mapping
- request External Runtime starts before launching dependent Direct Managed Processes
- block Direct Managed Processes when external dependencies cannot become available
- keep Process Claims limited to Direct Managed Processes

Closes #14

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build