### PR TITLE
feat: track external runtime session cleanup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -746,6 +746,7 @@ const startApp = async (
   const shutdown = createShutdownHandler({
     cwd: process.cwd(),
     manager,
+    externalRuntimeManager,
     getServicePids: () => manager.getServicePids(),
     logger: (message) => console.error(message),
   });

--- a/src/external-runtime.test.ts
+++ b/src/external-runtime.test.ts
@@ -7,15 +7,6 @@ import {
 } from "./external-runtime";
 import type { ExternalManagedProcess, LogEntry } from "./types";
 
-const process = (runtimeId: string, name: string): ExternalManagedProcess => ({
-  runtimeId,
-  runtimeName: runtimeId,
-  name,
-  state: "running",
-  status: "Up",
-  ports: "",
-});
-
 describe("detectExternalRuntimes", () => {
   test("asks each External Runtime Adapter whether it is available for the Project", async () => {
     const asked: string[] = [];
@@ -92,6 +83,60 @@ describe("ExternalRuntimeVisibilityManager", () => {
 
     expect(actions).toEqual(["podman:restart:cache"]);
   });
+
+  test("tracks and stops External Managed Processes auto-started for Startup Dependencies", async () => {
+    const actions: string[] = [];
+    let state: ExternalManagedProcess["state"] = "exited";
+    const testRuntime = runtime("docker", [process("docker", "db")], actions);
+    testRuntime.snapshot = async () => [process("docker", "db", state)];
+    testRuntime.start = async (name) => {
+      actions.push(`docker:start:${name}`);
+      state = "running";
+    };
+    const manager = new ExternalRuntimeVisibilityManager([testRuntime]);
+
+    await manager.ensureProcessAvailable("db");
+    await manager.stopSessionStartedProcesses();
+
+    expect(actions).toEqual(["docker:start:db", "docker:stop:db"]);
+  });
+
+  test("does not stop manually started External Managed Processes during session cleanup", async () => {
+    const actions: string[] = [];
+    let state: ExternalManagedProcess["state"] = "exited";
+    const testRuntime = runtime("docker", [process("docker", "db")], actions);
+    testRuntime.snapshot = async () => [process("docker", "db", state)];
+    testRuntime.start = async (name) => {
+      actions.push(`docker:start:${name}`);
+      state = "running";
+    };
+    const manager = new ExternalRuntimeVisibilityManager([testRuntime]);
+
+    await manager.refresh();
+    await manager.start("db");
+    await manager.stopSessionStartedProcesses();
+
+    expect(actions).toEqual(["docker:start:db"]);
+  });
+
+  test("reports failed External Runtime Session stop requests without throwing", async () => {
+    const messages: string[] = [];
+    let state: ExternalManagedProcess["state"] = "exited";
+    const testRuntime = runtime("docker", [process("docker", "db")]);
+    testRuntime.snapshot = async () => [process("docker", "db", state)];
+    testRuntime.start = async () => {
+      state = "running";
+    };
+    testRuntime.stop = async () => {
+      throw new Error("stop failed");
+    };
+    const manager = new ExternalRuntimeVisibilityManager([testRuntime]);
+
+    await manager.ensureProcessAvailable("db");
+    await manager.stopSessionStartedProcesses((message) => messages.push(message));
+
+    expect(messages).toEqual(['External Runtime cleanup warning for "docker:db": stop failed']);
+  });
 });
 
 const runtime = (
@@ -114,4 +159,17 @@ const runtime = (
   },
   streamOutput: (_name: string, _onOutput: (entry: LogEntry) => void) => null,
   destroy: async () => {},
+});
+
+const process = (
+  runtimeId: string,
+  name: string,
+  state: ExternalManagedProcess["state"] = "running",
+): ExternalManagedProcess => ({
+  runtimeId,
+  runtimeName: runtimeId,
+  name,
+  state,
+  status: "Up",
+  ports: "",
 });

--- a/src/external-runtime.ts
+++ b/src/external-runtime.ts
@@ -1,4 +1,5 @@
 import { LogBuffer } from "./log-buffer";
+import { getErrorMessage } from "./shared";
 import type { ExternalManagedProcess, LogEntry } from "./types";
 
 export type ExternalRuntimeUpdateCallback = () => void;
@@ -52,6 +53,8 @@ export class ExternalRuntimeVisibilityManager {
   private refreshing = false;
   private activeOutputStream: ExternalRuntimeOutputStream | null = null;
   private activeOutputKey: string | null = null;
+  private readonly sessionStartedProcesses: Map<string, { runtimeId: string; name: string }> =
+    new Map();
 
   constructor(runtimes: ExternalRuntime[]) {
     this.runtimes = runtimes;
@@ -188,7 +191,26 @@ export class ExternalRuntimeVisibilityManager {
     if (!updated) return false;
 
     runtime = this.runtimeFor(updated.runtimeId);
-    return runtime.isAvailable(updated);
+    const available = runtime.isAvailable(updated);
+    if (available) {
+      this.sessionStartedProcesses.set(processKey(updated), {
+        runtimeId: updated.runtimeId,
+        name: updated.name,
+      });
+    }
+    return available;
+  }
+
+  async stopSessionStartedProcesses(logger?: (message: string) => void): Promise<void> {
+    const records = [...this.sessionStartedProcesses.entries()].reverse();
+    for (const [key, record] of records) {
+      try {
+        await this.runtimeFor(record.runtimeId).stop(record.name);
+        this.sessionStartedProcesses.delete(key);
+      } catch (error) {
+        logger?.(`External Runtime cleanup warning for "${key}": ${getErrorMessage(error)}`);
+      }
+    }
   }
 
   async stop(name: string): Promise<void> {

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,3 +1,4 @@
+import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { removePidFilesForServices, removeServicePidFiles } from "./pidfile";
 import type { ServiceManager } from "./service-manager";
 import type { ServicePid } from "./types";
@@ -16,6 +17,7 @@ const SHUTDOWN_SIGNALS: NodeJS.Signals[] = [
 export type ShutdownContext = {
   cwd: string;
   manager: ServiceManager;
+  externalRuntimeManager?: ExternalRuntimeVisibilityManager | null;
   getServicePids: () => ServicePid[];
   onAfter?: () => Promise<void> | void;
   logger?: (message: string) => void;
@@ -24,6 +26,7 @@ export type ShutdownContext = {
 export const createShutdownHandler = ({
   cwd,
   manager,
+  externalRuntimeManager,
   getServicePids,
   onAfter,
   logger,
@@ -44,6 +47,7 @@ export const createShutdownHandler = ({
         await manager.forceStopAll();
         await manager.waitForExit(EXIT_WAIT_MS);
       }
+      await externalRuntimeManager?.stopSessionStartedProcesses(logger);
       await removeServicePidFiles(cwd, activeServicePids);
       await removePidFilesForServices(
         cwd,


### PR DESCRIPTION
## Summary
- record External Managed Processes auto-started to satisfy Startup Dependencies
- stop session-started External Managed Processes during shutdown through their External Runtime
- report failed external stop requests without failing direct Process Claim cleanup
- leave manually started External Managed Processes out of shutdown cleanup

Closes #15

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build