### PR TITLE
feat: extract setup and manifest editing flows

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,19 +1,18 @@
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { type KeyEvent, createCliRenderer } from "@opentui/core";
 import { createDockerComposeExternalRuntimeAdapter } from "./docker";
 import { ExternalRuntimeVisibilityManager, detectExternalRuntimes } from "./external-runtime";
 import { FocusManager } from "./focus";
+import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
 import {
-  DiscoverySelection,
-  detectServices,
-  finalizeSelection,
-  formatServiceSummary,
-  writeManifest,
-} from "./init";
-import { loadManifest, parseServiceBlock, renderServiceBlock, saveManifest } from "./manifest";
-import { normalizeProcessDefinition } from "./process-definition";
+  addProcessDefinition,
+  addSelectedDiscoveryCandidates,
+  removeSelectedProcessDefinition,
+  replaceProcessDefinition,
+} from "./manifest-editing";
+import { loadManifest, renderServiceBlock } from "./manifest";
 import { ProcessClaimStore } from "./process-claim";
-import { getTopologicalServiceOrder } from "./service-graph";
+import { createProjectManifest } from "./project-setup";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
 import { createShutdownHandler } from "./shutdown";
@@ -238,14 +237,11 @@ const setupKeybindings = (
       controls.clearEditError();
       const toml = controls.getEditContent();
       try {
-        const config = parseServiceBlock(toml, dirname(manifestPath));
-        const index = manager.getSelectedIndex();
-        const previousName = manager.getSelectedConfig()?.name;
-        await manager.updateServiceConfig(index, config);
-        await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-        if (previousName && previousName !== config.name) {
-          await processClaimStore.releaseDirectManagedProcessNames([previousName]);
-        }
+        await replaceProcessDefinition(
+          { manifestPath, appConfig, manager, processClaimStore },
+          manager.getSelectedIndex(),
+          toml,
+        );
       } catch (error) {
         controls.setEditError(getErrorMessage(error));
         return;
@@ -273,10 +269,10 @@ const setupKeybindings = (
       }
 
       try {
-        await manager.addService(
-          normalizeProcessDefinition({ name, command }, { baseDir: dirname(manifestPath) }),
+        await addProcessDefinition(
+          { manifestPath, appConfig, manager, processClaimStore },
+          { name, command },
         );
-        await saveManifest(manifestPath, manager.getConfigs(), appConfig);
         controls.hideAddOverlay();
         focusManager.setMode("normal");
       } catch (error) {
@@ -332,33 +328,18 @@ const setupKeybindings = (
         controls.clearDiscoveryError();
 
         try {
-          const finalized = finalizeSelection(selection, {
-            existingServices: manager.getConfigs(),
-            usedNames: manager.getConfigs().map((config) => config.name),
-          });
+          const previousCount = manager.getConfigs().length;
+          const result = await addSelectedDiscoveryCandidates(
+            { manifestPath, appConfig, manager, processClaimStore },
+            selection,
+          );
 
-          if (finalized.services.length === 0) {
+          if (result.services.length === previousCount) {
             controls.setDiscoveryError("Select at least one service to add.");
             return;
           }
 
-          const pendingByName = new Map(
-            finalized.services.map((service) => [service.name, service]),
-          );
-          const orderedNames = getTopologicalServiceOrder([
-            ...manager.getConfigs(),
-            ...finalized.services,
-          ]);
-
-          for (const serviceName of orderedNames) {
-            const service = pendingByName.get(serviceName);
-            if (!service) continue;
-            await manager.addService(service);
-          }
-
-          await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-
-          for (const warning of finalized.warnings) {
+          for (const warning of result.warnings) {
             console.error(`Discovery warning: ${warning}`);
           }
 
@@ -377,10 +358,12 @@ const setupKeybindings = (
 
   const handleDeleteConfirm = async (key: KeyEvent) => {
     if (key.name === "y") {
-      const removedName = manager.getSelectedConfig()?.name;
-      await manager.removeSelected();
-      await saveManifest(manifestPath, manager.getConfigs(), appConfig);
-      if (removedName) await processClaimStore.releaseDirectManagedProcessNames([removedName]);
+      await removeSelectedProcessDefinition({
+        manifestPath,
+        appConfig,
+        manager,
+        processClaimStore,
+      });
       deleteConfirming = false;
       controls.hideDeleteConfirm();
       return;
@@ -881,8 +864,7 @@ export const run = async () => {
 
     startInitFlow(renderer, teardownRef, runtime, async (selection, warnings) => {
       try {
-        const finalized = finalizeSelection(selection);
-        await writeManifest(manifestPath, finalized.services);
+        const finalized = await createProjectManifest(manifestPath, selection);
         renderer.destroy();
 
         console.log(`Created ${manifestPath}`);
@@ -962,10 +944,9 @@ export const run = async () => {
   const manifestPath = resolve(process.cwd(), MANIFEST_PATH);
   startInitFlow(renderer, teardownRef, runtime, async (selection) => {
     try {
-      const finalized = finalizeSelection(selection);
       teardownRef.current?.();
       teardownRef.current = null;
-      await writeManifest(manifestPath, finalized.services);
+      await createProjectManifest(manifestPath, selection);
       await startApp(renderer, teardownRef, shutdownRef, runtime);
     } catch (error) {
       console.error(getErrorMessage(error));

--- a/src/manifest-editing.test.ts
+++ b/src/manifest-editing.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LaunchInstructionExecutionAdapter } from "./launch-execution";
+import {
+  addProcessDefinition,
+  removeSelectedProcessDefinition,
+  replaceProcessDefinition,
+} from "./manifest-editing";
+import { loadManifest, renderServiceBlock, saveManifest } from "./manifest";
+import { normalizeProcessDefinition } from "./process-definition";
+import { ProcessClaimStore } from "./process-claim";
+import { ServiceManager } from "./service-manager";
+
+const launchPid = (pid: number): LaunchInstructionExecutionAdapter =>
+  new LaunchInstructionExecutionAdapter({
+    now: () => "now",
+    pathReader: async () => process.env.PATH ?? "",
+    processInfoReader: async (nextPid) => ({ pid: nextPid, startedAt: "started", command: null }),
+    spawner: () => ({
+      pid,
+      stdout: null,
+      stderr: null,
+      exited: new Promise(() => {}),
+      signalCode: null,
+      kill: () => {},
+    }),
+  });
+
+class TestClaims extends ProcessClaimStore {
+  releasedNames: string[] = [];
+
+  override async claimDirectManagedProcess(): Promise<void> {}
+
+  override async releaseDirectManagedProcess(): Promise<void> {}
+
+  override async releaseDirectManagedProcessNames(names: string[]): Promise<void> {
+    this.releasedNames.push(...names);
+  }
+}
+
+describe("Manifest Editing", () => {
+  test("adds a Process Definition through one persisted runtime apply flow", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      await saveManifest(manifestPath, []);
+      const claims = new TestClaims(dir);
+      const manager = new ServiceManager([], {
+        processClaimStore: claims,
+        launchAdapter: launchPid(30),
+      });
+
+      await addProcessDefinition(
+        { manifestPath, manager, processClaimStore: claims },
+        { name: "api", command: "bun run dev" },
+      );
+
+      const manifest = await loadManifest(manifestPath);
+      expect(manager.getConfigs().map((config) => config.name)).toEqual(["api"]);
+      expect(manifest.services.map((config) => config.name)).toEqual(["api"]);
+      expect(manager.getSelectedView()?.state).toBe("RUNNING");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("validates the next Process Definition collection before saving", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      await saveManifest(manifestPath, []);
+      const claims = new TestClaims(dir);
+      const manager = new ServiceManager([], { processClaimStore: claims });
+
+      await expect(
+        addProcessDefinition(
+          { manifestPath, manager, processClaimStore: claims },
+          { name: "api", command: "bun run dev", depends_on: ["missing"] },
+        ),
+      ).rejects.toThrow('depends on unknown service "missing"');
+
+      const manifest = await loadManifest(manifestPath);
+      expect(manifest.services).toEqual([]);
+      expect(manager.getConfigs()).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces a Process Definition and releases the old Process Claim name", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      await saveManifest(manifestPath, [original]);
+      const claims = new TestClaims(dir);
+      const manager = new ServiceManager([original], {
+        processClaimStore: claims,
+        launchAdapter: launchPid(31),
+      });
+      const view = manager.getSelectedView();
+      if (view) view.restartInMs = 123;
+
+      const replacement = normalizeProcessDefinition({ name: "web", command: "bun run dev" });
+      await replaceProcessDefinition(
+        { manifestPath, manager, processClaimStore: claims },
+        0,
+        renderServiceBlock(replacement),
+      );
+
+      const manifest = await loadManifest(manifestPath);
+      expect(manager.getConfigs().map((config) => config.name)).toEqual(["web"]);
+      expect(manifest.services.map((config) => config.name)).toEqual(["web"]);
+      expect(claims.releasedNames).toEqual(["api"]);
+      expect(manager.getSelectedView()?.restartInMs).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("deletes the selected Process Definition and releases its Process Claim name", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      await saveManifest(manifestPath, [original]);
+      const claims = new TestClaims(dir);
+      const manager = new ServiceManager([original], { processClaimStore: claims });
+
+      await removeSelectedProcessDefinition({ manifestPath, manager, processClaimStore: claims });
+
+      const manifest = await loadManifest(manifestPath);
+      expect(manager.getConfigs()).toEqual([]);
+      expect(manifest.services).toEqual([]);
+      expect(claims.releasedNames).toEqual(["api"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -1,0 +1,108 @@
+import { dirname } from "node:path";
+import { finalizeSelection, type DiscoverySelection } from "./discovery";
+import { DirectManagedProcessCollectionLifecycle } from "./direct-managed-process-collection";
+import { parseServiceBlock, saveManifest } from "./manifest";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
+import type { ProcessClaimStore } from "./process-claim";
+import { getTopologicalServiceOrder } from "./service-graph";
+import type { ServiceManager } from "./service-manager";
+import type { AppConfig, ServiceConfig } from "./types";
+
+export interface ManifestEditingContext {
+  manifestPath: string;
+  appConfig?: AppConfig;
+  manager: ServiceManager;
+  processClaimStore: ProcessClaimStore;
+}
+
+export interface ManifestEditingResult {
+  services: ServiceConfig[];
+  warnings: string[];
+}
+
+export const addProcessDefinition = async (
+  context: ManifestEditingContext,
+  input: ProcessDefinitionInput,
+): Promise<ManifestEditingResult> => {
+  const config = normalizeProcessDefinition(input, { baseDir: dirname(context.manifestPath) });
+  validateNextCollection([...context.manager.getConfigs(), config]);
+  await context.manager.addService(config);
+  await persist(context);
+  return { services: context.manager.getConfigs(), warnings: [] };
+};
+
+export const replaceProcessDefinition = async (
+  context: ManifestEditingContext,
+  index: number,
+  serviceBlockToml: string,
+): Promise<ManifestEditingResult> => {
+  const config = parseServiceBlock(serviceBlockToml, dirname(context.manifestPath));
+  const previousName = context.manager.getConfigs()[index]?.name;
+  const nextConfigs = context.manager
+    .getConfigs()
+    .map((entry, entryIndex) => (entryIndex === index ? config : entry));
+
+  validateNextCollection(nextConfigs);
+  await context.manager.updateServiceConfig(index, config);
+  await persist(context);
+
+  if (previousName && previousName !== config.name) {
+    await context.processClaimStore.releaseDirectManagedProcessNames([previousName]);
+  }
+
+  return { services: context.manager.getConfigs(), warnings: [] };
+};
+
+export const removeSelectedProcessDefinition = async (
+  context: ManifestEditingContext,
+): Promise<ManifestEditingResult> => {
+  const removedName = context.manager.getSelectedConfig()?.name;
+  const nextConfigs = context.manager
+    .getConfigs()
+    .filter((_, index) => index !== context.manager.getSelectedIndex());
+
+  validateNextCollection(nextConfigs);
+  await context.manager.removeSelected();
+  await persist(context);
+
+  if (removedName) await context.processClaimStore.releaseDirectManagedProcessNames([removedName]);
+
+  return { services: context.manager.getConfigs(), warnings: [] };
+};
+
+export const addSelectedDiscoveryCandidates = async (
+  context: ManifestEditingContext,
+  selection: DiscoverySelection,
+): Promise<ManifestEditingResult> => {
+  const finalized = finalizeSelection(selection, {
+    existingServices: context.manager.getConfigs(),
+    usedNames: context.manager.getConfigs().map((config) => config.name),
+  });
+
+  if (finalized.services.length === 0) {
+    return { services: context.manager.getConfigs(), warnings: finalized.warnings };
+  }
+
+  const nextConfigs = [...context.manager.getConfigs(), ...finalized.services];
+  validateNextCollection(nextConfigs);
+
+  const pendingByName = new Map(finalized.services.map((service) => [service.name, service]));
+  const orderedNames = getTopologicalServiceOrder(nextConfigs);
+
+  for (const serviceName of orderedNames) {
+    const service = pendingByName.get(serviceName);
+    if (!service) continue;
+    await context.manager.addService(service);
+  }
+
+  await persist(context);
+  return { services: context.manager.getConfigs(), warnings: finalized.warnings };
+};
+
+const validateNextCollection = (services: ServiceConfig[]): void => {
+  new DirectManagedProcessCollectionLifecycle(() => services).validate(services);
+};
+
+const persist = async (context: ManifestEditingContext): Promise<void> => {
+  await saveManifest(context.manifestPath, context.manager.getConfigs(), context.appConfig);
+};

--- a/src/project-setup.test.ts
+++ b/src/project-setup.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DiscoverySelection } from "./discovery";
+import { loadManifest } from "./manifest";
+import { normalizeProcessDefinition } from "./process-definition";
+import { createProjectManifest } from "./project-setup";
+import type { DetectedCandidate } from "./discovery";
+
+describe("createProjectManifest", () => {
+  test("creates an empty Manifest without requiring a Workspace", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-setup-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      const result = await createProjectManifest(manifestPath, null);
+      const manifest = await loadManifest(manifestPath);
+
+      expect(result.services).toEqual([]);
+      expect(manifest.services).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("creates a Manifest from selected Candidates", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-setup-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      const candidate: DetectedCandidate = {
+        strategyId: "node",
+        label: "Node",
+        priority: 10,
+        defaultSelected: true,
+        service: normalizeProcessDefinition({ name: "web", command: "bun run dev" }),
+        dependsOnIds: [],
+      };
+      const selection = new DiscoverySelection([candidate]);
+
+      const result = await createProjectManifest(manifestPath, selection);
+      const manifest = await loadManifest(manifestPath);
+
+      expect(result.services.map((service) => service.name)).toEqual(["web"]);
+      expect(manifest.services.map((service) => service.name)).toEqual(["web"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -1,0 +1,17 @@
+import { finalizeSelection, type DiscoverySelection } from "./discovery";
+import { writeManifest } from "./init";
+import type { ServiceConfig } from "./types";
+
+export interface ProjectSetupResult {
+  services: ServiceConfig[];
+  warnings: string[];
+}
+
+export const createProjectManifest = async (
+  manifestPath: string,
+  selection: DiscoverySelection | null,
+): Promise<ProjectSetupResult> => {
+  const finalized = selection ? finalizeSelection(selection) : { services: [], warnings: [] };
+  await writeManifest(manifestPath, finalized.services);
+  return finalized;
+};


### PR DESCRIPTION
## Summary
- extract Project Setup manifest creation into a renderer-free flow
- extract Manifest Editing add, replace, delete, and discovery-add operations into renderer-free flows
- validate next Process Definition collections before persistence
- keep runtime apply, persistence, Process Claim release, and Workspace feedback coordinated through shared flow calls
- add flow tests that avoid renderer setup and keypress simulation

Closes #16

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build