### PR TITLE
feat: extract workspace startup orchestration

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,6 @@
 import { resolve } from "node:path";
 import { type KeyEvent, createCliRenderer } from "@opentui/core";
-import { createDockerComposeExternalRuntimeAdapter } from "./docker";
-import { ExternalRuntimeVisibilityManager, detectExternalRuntimes } from "./external-runtime";
+import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
 import {
@@ -10,22 +9,16 @@ import {
   removeSelectedProcessDefinition,
   replaceProcessDefinition,
 } from "./manifest-editing";
-import { loadManifest, renderServiceBlock } from "./manifest";
+import { renderServiceBlock } from "./manifest";
 import { ProcessClaimStore } from "./process-claim";
 import { createProjectManifest } from "./project-setup";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
-import { createShutdownHandler } from "./shutdown";
-import type { AppConfig, Shortcut } from "./types";
+import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
+import { startWorkspace, type ShutdownController } from "./workspace-startup";
 
 const MANIFEST_PATH = "stasium.toml";
-
-type ShutdownController = {
-  run: (reason?: string) => Promise<void>;
-  install: () => void;
-  uninstall: () => void;
-};
 
 type AppRuntime = {
   disposed: boolean;
@@ -649,9 +642,6 @@ const setupKeybindings = (
   });
 };
 
-const isExternalRuntimeVisibilityEnabled = (appConfig: AppConfig | undefined): boolean =>
-  appConfig?.docker?.enabled ?? true;
-
 const mountMainUiSession = (
   renderer: Awaited<ReturnType<typeof createCliRenderer>>,
   teardownRef: { current: (() => void) | null },
@@ -659,9 +649,10 @@ const mountMainUiSession = (
   shutdown: ShutdownController,
   manifestPath: string,
   manager: ServiceManager,
-  manifest: Awaited<ReturnType<typeof loadManifest>>,
+  manifest: Manifest,
   appConfig: AppConfig | undefined,
   externalRuntimeManager: ExternalRuntimeVisibilityManager | null,
+  processClaimStore: ProcessClaimStore,
 ): MainUiSession => {
   const focusManager = new FocusManager(externalRuntimeManager !== null);
   const { teardown, controls } = buildUi({
@@ -686,14 +677,10 @@ const mountMainUiSession = (
     appConfig,
     runtime,
     shutdown,
-    new ProcessClaimStore(process.cwd(), { logger: (message) => console.error(message) }),
+    processClaimStore,
   );
 
   controls.renderAll();
-
-  if (externalRuntimeManager && !runtime.closing && !runtime.disposed) {
-    externalRuntimeManager.startPolling();
-  }
 
   return {
     teardown,
@@ -709,59 +696,39 @@ const startApp = async (
   shutdownRef: { current: ShutdownController | null },
   runtime: AppRuntime,
 ) => {
-  const manifest = await loadManifest(MANIFEST_PATH);
-  const processClaimStore = new ProcessClaimStore(process.cwd(), {
-    logger: (message) => console.error(message),
-  });
-  const appConfig = manifest.app;
   const manifestPath = resolve(process.cwd(), MANIFEST_PATH);
-  const externalRuntimes = isExternalRuntimeVisibilityEnabled(appConfig)
-    ? await detectExternalRuntimes(process.cwd(), [createDockerComposeExternalRuntimeAdapter()])
-    : [];
-  const externalRuntimeManager =
-    externalRuntimes.length > 0 ? new ExternalRuntimeVisibilityManager(externalRuntimes) : null;
-  const manager = new ServiceManager(manifest.services, {
-    processClaimStore,
-    externalRuntimeManager,
-  });
-
   shutdownRef.current?.uninstall();
-  const shutdown = createShutdownHandler({
+
+  await startWorkspace({
     cwd: process.cwd(),
-    manager,
-    externalRuntimeManager,
-    getServicePids: () => manager.getServicePids(),
-    logger: (message) => console.error(message),
-  });
-  shutdown.install();
-  shutdownRef.current = shutdown;
-
-  mountMainUiSession(
-    renderer,
-    teardownRef,
-    runtime,
-    shutdown,
     manifestPath,
-    manager,
-    manifest,
-    appConfig,
-    externalRuntimeManager,
-  );
-
-  void (async () => {
-    try {
-      await processClaimStore.cleanupStaleDirectManagedProcessClaims(
-        manifest.services.map((service) => service.name),
+    runtime,
+    logger: (message) => console.error(message),
+    onShutdownReady: (shutdown) => {
+      shutdownRef.current = shutdown;
+    },
+    mountWorkspace: ({
+      manifest,
+      appConfig,
+      manager,
+      processClaimStore,
+      externalRuntimeManager,
+      shutdown,
+    }) => {
+      mountMainUiSession(
+        renderer,
+        teardownRef,
+        runtime,
+        shutdown,
+        manifestPath,
+        manager,
+        manifest,
+        appConfig,
+        externalRuntimeManager,
+        processClaimStore,
       );
-      if (runtime.closing || runtime.disposed) return;
-
-      await manager.startAll({
-        shouldCancel: () => runtime.closing || runtime.disposed,
-      });
-    } catch (error) {
-      console.error(getErrorMessage(error));
-    }
-  })();
+    },
+  });
 };
 
 const startInitFlow = (

--- a/src/workspace-startup.test.ts
+++ b/src/workspace-startup.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { saveManifest } from "./manifest";
+import { normalizeProcessDefinition } from "./process-definition";
+import { startWorkspace } from "./workspace-startup";
+import type { ExternalRuntime, ExternalRuntimeAdapter } from "./external-runtime";
+import type { ExternalManagedProcess, LogEntry } from "./types";
+
+describe("startWorkspace", () => {
+  test("mounts the Workspace before Startup while External Runtime polling continues", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-workspace-"));
+    const manifestPath = join(dir, "stasium.toml");
+    const events: string[] = [];
+    try {
+      await saveManifest(manifestPath, []);
+      const adapter: ExternalRuntimeAdapter = {
+        id: "docker",
+        name: "Docker Compose",
+        detect: async () => {
+          events.push("detect external runtimes");
+          return externalRuntime(events);
+        },
+      };
+
+      const session = await startWorkspace({
+        cwd: dir,
+        manifestPath,
+        runtime: { closing: false, disposed: false },
+        externalRuntimeAdapters: [adapter],
+        mountWorkspace: () => {
+          events.push("mount workspace");
+        },
+      });
+      await session.startup;
+      await session.shutdown.run();
+      await session.externalRuntimeManager?.destroy();
+
+      expect(events.slice(0, 3)).toEqual([
+        "detect external runtimes",
+        "mount workspace",
+        "poll external runtime",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runs Startup after mounting so Process State can update live", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-workspace-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      await saveManifest(manifestPath, [
+        normalizeProcessDefinition({
+          name: "api",
+          command: ["bun", "-e", "setInterval(() => {}, 1000)"],
+        }),
+      ]);
+
+      const session = await startWorkspace({
+        cwd: dir,
+        manifestPath,
+        runtime: { closing: false, disposed: false },
+        externalRuntimeVisibilityEnabled: () => false,
+        mountWorkspace: (context) => {
+          expect(context.manager.getSelectedView()?.state).toBe("STOPPED");
+        },
+      });
+
+      await session.startup;
+      expect(session.manager.getSelectedView()?.state).toBe("RUNNING");
+      await session.shutdown.run();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+const externalRuntime = (events: string[]): ExternalRuntime => ({
+  id: "docker",
+  name: "Docker Compose",
+  snapshot: async () => {
+    events.push("poll external runtime");
+    return [externalProcess()];
+  },
+  isAvailable: (process) => process.state === "running",
+  start: async () => {},
+  stop: async () => {},
+  restart: async () => {},
+  streamOutput: (_name: string, _onOutput: (entry: LogEntry) => void) => null,
+  destroy: async () => {},
+});
+
+const externalProcess = (): ExternalManagedProcess => ({
+  runtimeId: "docker",
+  runtimeName: "Docker Compose",
+  name: "db",
+  state: "running",
+  status: "Up",
+  ports: "",
+});

--- a/src/workspace-startup.ts
+++ b/src/workspace-startup.ts
@@ -1,0 +1,114 @@
+import { createDockerComposeExternalRuntimeAdapter } from "./docker";
+import {
+  ExternalRuntimeVisibilityManager,
+  detectExternalRuntimes,
+  type ExternalRuntimeAdapter,
+} from "./external-runtime";
+import { loadManifest } from "./manifest";
+import { ProcessClaimStore } from "./process-claim";
+import { ServiceManager } from "./service-manager";
+import { createShutdownHandler } from "./shutdown";
+import type { AppConfig, Manifest } from "./types";
+
+export interface WorkspaceRuntimeState {
+  closing: boolean;
+  disposed: boolean;
+}
+
+export type ShutdownController = ReturnType<typeof createShutdownHandler>;
+
+export interface WorkspaceStartupMountContext {
+  manifest: Manifest;
+  manifestPath: string;
+  appConfig: AppConfig | undefined;
+  manager: ServiceManager;
+  processClaimStore: ProcessClaimStore;
+  externalRuntimeManager: ExternalRuntimeVisibilityManager | null;
+  shutdown: ShutdownController;
+}
+
+export interface WorkspaceStartupOptions {
+  cwd: string;
+  manifestPath: string;
+  runtime: WorkspaceRuntimeState;
+  logger?: (message: string) => void;
+  externalRuntimeVisibilityEnabled?: (appConfig: AppConfig | undefined) => boolean;
+  externalRuntimeAdapters?: ExternalRuntimeAdapter[];
+  onShutdownReady?: (shutdown: ShutdownController) => void;
+  mountWorkspace: (context: WorkspaceStartupMountContext) => void;
+}
+
+export interface WorkspaceStartupSession extends WorkspaceStartupMountContext {
+  startup: Promise<void>;
+}
+
+export const isExternalRuntimeVisibilityEnabled = (appConfig: AppConfig | undefined): boolean =>
+  appConfig?.docker?.enabled ?? true;
+
+export const startWorkspace = async (
+  options: WorkspaceStartupOptions,
+): Promise<WorkspaceStartupSession> => {
+  const manifest = await loadManifest(options.manifestPath);
+  const appConfig = manifest.app;
+  const logger = options.logger;
+  const processClaimStore = new ProcessClaimStore(options.cwd, { logger });
+  const externalRuntimeAdapters = options.externalRuntimeAdapters ?? [
+    createDockerComposeExternalRuntimeAdapter(),
+  ];
+  const externalRuntimes = (
+    options.externalRuntimeVisibilityEnabled ?? isExternalRuntimeVisibilityEnabled
+  )(appConfig)
+    ? await detectExternalRuntimes(options.cwd, externalRuntimeAdapters)
+    : [];
+  const externalRuntimeManager =
+    externalRuntimes.length > 0 ? new ExternalRuntimeVisibilityManager(externalRuntimes) : null;
+  const manager = new ServiceManager(manifest.services, {
+    processClaimStore,
+    externalRuntimeManager,
+  });
+  const shutdown = createShutdownHandler({
+    cwd: options.cwd,
+    manager,
+    externalRuntimeManager,
+    getServicePids: () => manager.getServicePids(),
+    logger,
+  });
+
+  shutdown.install();
+  options.onShutdownReady?.(shutdown);
+
+  const context: WorkspaceStartupMountContext = {
+    manifest,
+    manifestPath: options.manifestPath,
+    appConfig,
+    manager,
+    processClaimStore,
+    externalRuntimeManager,
+    shutdown,
+  };
+
+  options.mountWorkspace(context);
+  externalRuntimeManager?.startPolling();
+
+  const startup = runStartup(context, options.runtime, logger);
+  return { ...context, startup };
+};
+
+const runStartup = async (
+  context: WorkspaceStartupMountContext,
+  runtime: WorkspaceRuntimeState,
+  logger?: (message: string) => void,
+): Promise<void> => {
+  try {
+    await context.processClaimStore.cleanupStaleDirectManagedProcessClaims(
+      context.manifest.services.map((service) => service.name),
+    );
+    if (runtime.closing || runtime.disposed) return;
+
+    await context.manager.startAll({
+      shouldCancel: () => runtime.closing || runtime.disposed,
+    });
+  } catch (error) {
+    logger?.(error instanceof Error ? error.message : String(error ?? ""));
+  }
+};


### PR DESCRIPTION
## Summary
- add a Workspace startup flow that loads the Manifest, detects External Runtimes, creates Direct/External runtime models, mounts the Workspace, then starts processes asynchronously
- keep External Runtime Visibility polling owned by startup orchestration after mount
- route Shutdown setup through the flow so Direct shutdown, Process Claim cleanup, and External Runtime Session cleanup stay coordinated
- simplify app orchestration to UI mounting and renderer lifecycle concerns

Closes #17

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build