### PR TITLE
fix: make manifest editing transactional

### DIFF
--- a/src/manifest-editing.test.ts
+++ b/src/manifest-editing.test.ts
@@ -89,6 +89,25 @@ describe("Manifest Editing", () => {
     }
   });
 
+  test("does not apply a Process Definition when the Manifest cannot be saved", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    try {
+      const claims = new TestClaims(dir);
+      const manager = new ServiceManager([], { processClaimStore: claims });
+
+      await expect(
+        addProcessDefinition(
+          { manifestPath: dir, manager, processClaimStore: claims },
+          { name: "api", command: "bun run dev" },
+        ),
+      ).rejects.toThrow();
+
+      expect(manager.getConfigs()).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("replaces a Process Definition and releases the old Process Claim name", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     const manifestPath = join(dir, "stasium.toml");
@@ -115,6 +134,29 @@ describe("Manifest Editing", () => {
       expect(manifest.services.map((config) => config.name)).toEqual(["web"]);
       expect(claims.releasedNames).toEqual(["api"]);
       expect(manager.getSelectedView()?.restartInMs).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("does not replace or release claims when the Manifest cannot be saved", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    try {
+      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      const claims = new TestClaims(dir);
+      const manager = new ServiceManager([original], { processClaimStore: claims });
+      const replacement = normalizeProcessDefinition({ name: "web", command: "bun run dev" });
+
+      await expect(
+        replaceProcessDefinition(
+          { manifestPath: dir, manager, processClaimStore: claims },
+          0,
+          renderServiceBlock(replacement),
+        ),
+      ).rejects.toThrow();
+
+      expect(manager.getConfigs().map((config) => config.name)).toEqual(["api"]);
+      expect(claims.releasedNames).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/manifest-editing.test.ts
+++ b/src/manifest-editing.test.ts
@@ -40,6 +40,12 @@ class TestClaims extends ProcessClaimStore {
   }
 }
 
+class FailingReleaseClaims extends TestClaims {
+  override async releaseDirectManagedProcessNames(): Promise<void> {
+    throw new Error("release failed");
+  }
+}
+
 describe("Manifest Editing", () => {
   test("adds a Process Definition through one persisted runtime apply flow", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
@@ -157,6 +163,31 @@ describe("Manifest Editing", () => {
 
       expect(manager.getConfigs().map((config) => config.name)).toEqual(["api"]);
       expect(claims.releasedNames).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports Process Claim release failures as warnings after a successful edit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      await saveManifest(manifestPath, [original]);
+      const claims = new FailingReleaseClaims(dir);
+      const manager = new ServiceManager([original], { processClaimStore: claims });
+      const replacement = normalizeProcessDefinition({ name: "web", command: "bun run dev" });
+
+      const result = await replaceProcessDefinition(
+        { manifestPath, manager, processClaimStore: claims },
+        0,
+        renderServiceBlock(replacement),
+      );
+
+      const manifest = await loadManifest(manifestPath);
+      expect(manager.getConfigs().map((config) => config.name)).toEqual(["web"]);
+      expect(manifest.services.map((config) => config.name)).toEqual(["web"]);
+      expect(result.warnings).toEqual(["Failed to release Process Claims: release failed"]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -6,6 +6,7 @@ import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./proce
 import type { ProcessClaimStore } from "./process-claim";
 import { getTopologicalServiceOrder } from "./service-graph";
 import type { ServiceManager } from "./service-manager";
+import { getErrorMessage } from "./shared";
 import type { AppConfig, ServiceConfig } from "./types";
 
 export interface ManifestEditingContext {
@@ -116,11 +117,19 @@ const applyManifestEdit = async (
   await saveManifest(context.manifestPath, transaction.nextConfigs, context.appConfig);
   await transaction.apply();
 
+  const warnings: string[] = [];
+
   if (transaction.releaseClaimNames && transaction.releaseClaimNames.length > 0) {
-    await context.processClaimStore.releaseDirectManagedProcessNames(transaction.releaseClaimNames);
+    try {
+      await context.processClaimStore.releaseDirectManagedProcessNames(
+        transaction.releaseClaimNames,
+      );
+    } catch (error) {
+      warnings.push(`Failed to release Process Claims: ${getErrorMessage(error)}`);
+    }
   }
 
-  return { services: context.manager.getConfigs(), warnings: [] };
+  return { services: context.manager.getConfigs(), warnings };
 };
 
 const validateNextCollection = (services: ServiceConfig[]): void => {

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -20,15 +20,23 @@ export interface ManifestEditingResult {
   warnings: string[];
 }
 
+interface ManifestEditTransaction {
+  nextConfigs: ServiceConfig[];
+  apply: () => Promise<void>;
+  releaseClaimNames?: string[];
+}
+
 export const addProcessDefinition = async (
   context: ManifestEditingContext,
   input: ProcessDefinitionInput,
 ): Promise<ManifestEditingResult> => {
   const config = normalizeProcessDefinition(input, { baseDir: dirname(context.manifestPath) });
-  validateNextCollection([...context.manager.getConfigs(), config]);
-  await context.manager.addService(config);
-  await persist(context);
-  return { services: context.manager.getConfigs(), warnings: [] };
+  return applyManifestEdit(context, {
+    nextConfigs: [...context.manager.getConfigs(), config],
+    apply: async () => {
+      await context.manager.addService(config);
+    },
+  });
 };
 
 export const replaceProcessDefinition = async (
@@ -42,15 +50,13 @@ export const replaceProcessDefinition = async (
     .getConfigs()
     .map((entry, entryIndex) => (entryIndex === index ? config : entry));
 
-  validateNextCollection(nextConfigs);
-  await context.manager.updateServiceConfig(index, config);
-  await persist(context);
-
-  if (previousName && previousName !== config.name) {
-    await context.processClaimStore.releaseDirectManagedProcessNames([previousName]);
-  }
-
-  return { services: context.manager.getConfigs(), warnings: [] };
+  return applyManifestEdit(context, {
+    nextConfigs,
+    apply: async () => {
+      await context.manager.updateServiceConfig(index, config);
+    },
+    releaseClaimNames: previousName && previousName !== config.name ? [previousName] : [],
+  });
 };
 
 export const removeSelectedProcessDefinition = async (
@@ -61,13 +67,13 @@ export const removeSelectedProcessDefinition = async (
     .getConfigs()
     .filter((_, index) => index !== context.manager.getSelectedIndex());
 
-  validateNextCollection(nextConfigs);
-  await context.manager.removeSelected();
-  await persist(context);
-
-  if (removedName) await context.processClaimStore.releaseDirectManagedProcessNames([removedName]);
-
-  return { services: context.manager.getConfigs(), warnings: [] };
+  return applyManifestEdit(context, {
+    nextConfigs,
+    apply: async () => {
+      await context.manager.removeSelected();
+    },
+    releaseClaimNames: removedName ? [removedName] : [],
+  });
 };
 
 export const addSelectedDiscoveryCandidates = async (
@@ -89,20 +95,34 @@ export const addSelectedDiscoveryCandidates = async (
   const pendingByName = new Map(finalized.services.map((service) => [service.name, service]));
   const orderedNames = getTopologicalServiceOrder(nextConfigs);
 
-  for (const serviceName of orderedNames) {
-    const service = pendingByName.get(serviceName);
-    if (!service) continue;
-    await context.manager.addService(service);
+  const result = await applyManifestEdit(context, {
+    nextConfigs,
+    apply: async () => {
+      for (const serviceName of orderedNames) {
+        const service = pendingByName.get(serviceName);
+        if (!service) continue;
+        await context.manager.addService(service);
+      }
+    },
+  });
+  return { ...result, warnings: finalized.warnings };
+};
+
+const applyManifestEdit = async (
+  context: ManifestEditingContext,
+  transaction: ManifestEditTransaction,
+): Promise<ManifestEditingResult> => {
+  validateNextCollection(transaction.nextConfigs);
+  await saveManifest(context.manifestPath, transaction.nextConfigs, context.appConfig);
+  await transaction.apply();
+
+  if (transaction.releaseClaimNames && transaction.releaseClaimNames.length > 0) {
+    await context.processClaimStore.releaseDirectManagedProcessNames(transaction.releaseClaimNames);
   }
 
-  await persist(context);
-  return { services: context.manager.getConfigs(), warnings: finalized.warnings };
+  return { services: context.manager.getConfigs(), warnings: [] };
 };
 
 const validateNextCollection = (services: ServiceConfig[]): void => {
   new DirectManagedProcessCollectionLifecycle(() => services).validate(services);
-};
-
-const persist = async (context: ManifestEditingContext): Promise<void> => {
-  await saveManifest(context.manifestPath, context.manager.getConfigs(), context.appConfig);
 };


### PR DESCRIPTION
## Summary
- Route add, replace, delete, and Candidate Selection additions through one Manifest Editing transaction helper
- Validate and save the intended Manifest before mutating the active Workspace
- Release renamed/removed Process Claims only after a successful runtime apply

## Tests
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #42