### PR TITLE
feat: add update channel decision model

### DIFF
--- a/src/update-channel.test.ts
+++ b/src/update-channel.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from "bun:test";
+import { decideUpdate } from "./update-channel";
+
+describe("Update Channel decision model", () => {
+  test("selects a newer release artifact for the requested platform", () => {
+    const decision = decideUpdate({
+      currentVersion: "0.1.0",
+      channel: "stable",
+      platform: { os: "linux", arch: "x64" },
+      releases: [
+        {
+          version: "0.2.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/stasium-linux-x64",
+              sha256: "abc123",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "update-available",
+      currentVersion: "0.1.0",
+      latestVersion: "0.2.0",
+      channel: "stable",
+      artifact: {
+        platform: { os: "linux", arch: "x64" },
+        name: "stasium-linux-x64",
+        url: "https://example.com/stasium-linux-x64",
+        sha256: "abc123",
+      },
+    });
+  });
+
+  test("reports up to date when the channel has no newer release", () => {
+    const decision = decideUpdate({
+      currentVersion: "0.2.0",
+      channel: "stable",
+      platform: { os: "linux", arch: "x64" },
+      releases: [
+        {
+          version: "0.2.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/stasium-linux-x64",
+              sha256: "abc123",
+            },
+          ],
+        },
+        {
+          version: "0.1.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/old/stasium-linux-x64",
+              sha256: "def456",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "up-to-date",
+      currentVersion: "0.2.0",
+      channel: "stable",
+    });
+  });
+
+  test("reports unsupported platform when a newer release has no matching artifact", () => {
+    const decision = decideUpdate({
+      currentVersion: "0.1.0",
+      channel: "stable",
+      platform: { os: "linux", arch: "arm64" },
+      releases: [
+        {
+          version: "0.2.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/stasium-linux-x64",
+              sha256: "abc123",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "unsupported-platform",
+      currentVersion: "0.1.0",
+      latestVersion: "0.2.0",
+      channel: "stable",
+      platform: { os: "linux", arch: "arm64" },
+    });
+  });
+
+  test("reports unavailable channel when no release belongs to the selected channel", () => {
+    const decision = decideUpdate({
+      currentVersion: "0.1.0",
+      channel: "stable",
+      platform: { os: "linux", arch: "x64" },
+      releases: [
+        {
+          version: "0.2.0",
+          channel: "nightly",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/stasium-linux-x64",
+              sha256: "abc123",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "channel-unavailable",
+      currentVersion: "0.1.0",
+      channel: "stable",
+      reason: "No releases found for channel stable.",
+    });
+  });
+
+  test("reports failure when version metadata is invalid", () => {
+    const decision = decideUpdate({
+      currentVersion: "0.1.0",
+      channel: "stable",
+      platform: { os: "linux", arch: "x64" },
+      releases: [
+        {
+          version: "next",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/stasium-linux-x64",
+              sha256: "abc123",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "failure",
+      currentVersion: "0.1.0",
+      channel: "stable",
+      reason: 'Invalid update version "next".',
+    });
+  });
+
+  test("reports failure when the current version is invalid", () => {
+    const decision = decideUpdate({
+      currentVersion: "dev",
+      channel: "stable",
+      platform: { os: "linux", arch: "x64" },
+      releases: [
+        {
+          version: "0.2.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "linux", arch: "x64" },
+              name: "stasium-linux-x64",
+              url: "https://example.com/stasium-linux-x64",
+              sha256: "abc123",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "failure",
+      currentVersion: "dev",
+      channel: "stable",
+      reason: 'Invalid current version "dev".',
+    });
+  });
+
+  test("selects the newest release from unordered channel metadata", () => {
+    const decision = decideUpdate({
+      currentVersion: "0.1.0",
+      channel: "stable",
+      platform: { os: "macos", arch: "arm64" },
+      releases: [
+        {
+          version: "0.2.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "macos", arch: "arm64" },
+              name: "stasium-macos-arm64",
+              url: "https://example.com/0.2.0/stasium-macos-arm64",
+              sha256: "older",
+            },
+          ],
+        },
+        {
+          version: "0.3.0",
+          channel: "stable",
+          artifacts: [
+            {
+              platform: { os: "macos", arch: "arm64" },
+              name: "stasium-macos-arm64",
+              url: "https://example.com/0.3.0/stasium-macos-arm64",
+              sha256: "newer",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(decision).toEqual({
+      type: "update-available",
+      currentVersion: "0.1.0",
+      latestVersion: "0.3.0",
+      channel: "stable",
+      artifact: {
+        platform: { os: "macos", arch: "arm64" },
+        name: "stasium-macos-arm64",
+        url: "https://example.com/0.3.0/stasium-macos-arm64",
+        sha256: "newer",
+      },
+    });
+  });
+});

--- a/src/update-channel.ts
+++ b/src/update-channel.ts
@@ -1,0 +1,165 @@
+export type UpdateChannelName = "stable" | string;
+
+export type UpdatePlatform = {
+  os: "linux" | "macos" | "windows" | string;
+  arch: "x64" | "arm64" | string;
+};
+
+export interface UpdateArtifact {
+  platform: UpdatePlatform;
+  name: string;
+  url: string;
+  sha256: string;
+}
+
+export interface UpdateRelease {
+  version: string;
+  channel: UpdateChannelName;
+  artifacts: UpdateArtifact[];
+}
+
+export interface UpdateDecisionInput {
+  currentVersion: string;
+  channel: UpdateChannelName;
+  platform: UpdatePlatform;
+  releases: UpdateRelease[];
+}
+
+export type UpdateDecision =
+  | {
+      type: "update-available";
+      currentVersion: string;
+      latestVersion: string;
+      channel: UpdateChannelName;
+      artifact: UpdateArtifact;
+    }
+  | {
+      type: "up-to-date";
+      currentVersion: string;
+      channel: UpdateChannelName;
+    }
+  | {
+      type: "unsupported-platform";
+      currentVersion: string;
+      latestVersion: string;
+      channel: UpdateChannelName;
+      platform: UpdatePlatform;
+    }
+  | {
+      type: "channel-unavailable";
+      currentVersion: string;
+      channel: UpdateChannelName;
+      reason: string;
+    }
+  | {
+      type: "failure";
+      currentVersion: string;
+      channel: UpdateChannelName;
+      reason: string;
+    };
+
+const parseVersion = (version: string): number[] | null => {
+  const parts = version.split(".");
+  if (parts.length !== 3) return null;
+  const parsed = parts.map((part) => Number(part));
+  if (parsed.some((part) => !Number.isInteger(part) || part < 0)) return null;
+  return parsed;
+};
+
+const compareVersions = (left: string, right: string): number | null => {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  if (!leftParts || !rightParts) return null;
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = leftParts[index] ?? 0;
+    const rightPart = rightParts[index] ?? 0;
+    if (leftPart > rightPart) return 1;
+    if (leftPart < rightPart) return -1;
+  }
+
+  return 0;
+};
+
+export const decideUpdate = (input: UpdateDecisionInput): UpdateDecision => {
+  if (!parseVersion(input.currentVersion)) {
+    return {
+      type: "failure",
+      currentVersion: input.currentVersion,
+      channel: input.channel,
+      reason: `Invalid current version "${input.currentVersion}".`,
+    };
+  }
+
+  const channelReleases = input.releases.filter((entry) => entry.channel === input.channel);
+  let release = channelReleases[0];
+
+  for (const candidate of channelReleases.slice(1)) {
+    if (!release) {
+      release = candidate;
+      continue;
+    }
+
+    const versionComparison = compareVersions(candidate.version, release.version);
+    if (versionComparison === null) {
+      return {
+        type: "failure",
+        currentVersion: input.currentVersion,
+        channel: input.channel,
+        reason: `Invalid update version "${candidate.version}".`,
+      };
+    }
+
+    if (versionComparison > 0) release = candidate;
+  }
+
+  if (!release) {
+    return {
+      type: "channel-unavailable",
+      currentVersion: input.currentVersion,
+      channel: input.channel,
+      reason: `No releases found for channel ${input.channel}.`,
+    };
+  }
+
+  const versionComparison = compareVersions(release.version, input.currentVersion);
+  if (versionComparison === null) {
+    return {
+      type: "failure",
+      currentVersion: input.currentVersion,
+      channel: input.channel,
+      reason: `Invalid update version "${release.version}".`,
+    };
+  }
+
+  if (versionComparison <= 0) {
+    return {
+      type: "up-to-date",
+      currentVersion: input.currentVersion,
+      channel: input.channel,
+    };
+  }
+
+  const artifact = release.artifacts.find(
+    (entry) =>
+      entry.platform.os === input.platform.os && entry.platform.arch === input.platform.arch,
+  );
+  if (!artifact) {
+    return {
+      type: "unsupported-platform",
+      currentVersion: input.currentVersion,
+      latestVersion: release.version,
+      channel: input.channel,
+      platform: input.platform,
+    };
+  }
+
+  return {
+    type: "update-available",
+    currentVersion: input.currentVersion,
+    latestVersion: release.version,
+    channel: input.channel,
+    artifact,
+  };
+};


### PR DESCRIPTION
## Summary
- Add the core Update Channel decision model for startup auto-updates
- Centralize semantic version comparison and selected-channel filtering
- Represent update available, up to date, unsupported platform, unavailable channel, and failure outcomes without network or file replacement

## Tests
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #51
Part of #50