### PR TITLE
feat: add startup auto update flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Set release version
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          printf 'export const STASIUM_VERSION = "%s";\n' "$version" > src/version.ts
+
       - name: Build binary
         run: bun run build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "1.3.10"
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -87,6 +92,14 @@ jobs:
         working-directory: release
         run: sha256sum * > checksums.txt
 
+      - name: Generate update metadata
+        run: |
+          bun scripts/generate-update-metadata.ts \
+            "$GITHUB_REF_NAME" \
+            "https://github.com/modoterra/stasium/releases/download/$GITHUB_REF_NAME" \
+            release/checksums.txt \
+            release/update-stable.json
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -98,4 +111,5 @@ jobs:
             release/stasium-linux-arm64 \
             release/stasium-macos-arm64 \
             release/stasium-windows-x64.exe \
+            release/update-stable.json \
             release/checksums.txt

--- a/README.md
+++ b/README.md
@@ -26,6 +26,44 @@ irm https://raw.githubusercontent.com/modoterra/stasium/main/install.ps1 | iex
 | `stasium-macos-arm64`     | macOS Apple Silicon |
 | `stasium-windows-x64.exe` | Windows x86_64      |
 
+## Startup Updates
+
+Stasium checks the stable Update Channel on startup before opening Project Setup or the Workspace.
+Update checks are bounded and fail open: network failures, unavailable metadata, unsupported
+platforms, and unsafe installs are reported as warnings and do not stop normal usage.
+
+Release assets are checksum-verified before Stasium replaces a binary. Stasium only self-updates
+executables that look like Stasium binaries; package-manager-owned installs, development runs, or
+other unsafe paths fall back to manual update instructions.
+
+Startup update preferences live outside project Manifests at:
+
+```text
+~/.config/stasium/update.json
+```
+
+Default preferences:
+
+```json
+{
+  "enabled": true,
+  "channel": "stable"
+}
+```
+
+To disable startup update checks:
+
+```json
+{
+  "enabled": false,
+  "channel": "stable"
+}
+```
+
+Supported auto-update assets match the release binaries listed above. If Stasium reports that an
+update cannot be applied automatically, download the matching asset from GitHub Releases and replace
+your installed binary manually or through the package manager that installed it.
+
 ## Development
 
 Install dependencies:

--- a/scripts/generate-update-metadata.ts
+++ b/scripts/generate-update-metadata.ts
@@ -1,0 +1,13 @@
+import { generateUpdateMetadata, parseChecksums } from "../src/update-release-metadata";
+
+const [version, baseUrl, checksumsPath, outputPath] = process.argv.slice(2);
+
+if (!version || !baseUrl || !checksumsPath || !outputPath) {
+  throw new Error(
+    "Usage: bun scripts/generate-update-metadata.ts <version> <base-url> <checksums-path> <output-path>",
+  );
+}
+
+const checksums = parseChecksums(await Bun.file(checksumsPath).text());
+const metadata = generateUpdateMetadata({ version, baseUrl, checksums });
+await Bun.write(outputPath, `${JSON.stringify(metadata, null, 2)}\n`);

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,8 +14,10 @@ import { ProcessClaimStore } from "./process-claim";
 import { createProjectManifest } from "./project-setup";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
+import { currentUpdatePlatform, runStartupUpdateCheck } from "./startup-update";
 import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
+import { STASIUM_VERSION } from "./version";
 import { startWorkspace, type ShutdownController } from "./workspace-startup";
 
 const MANIFEST_PATH = "stasium.toml";
@@ -803,6 +805,15 @@ export const run = async () => {
     externalRuntimeManager: null,
     exitCode: null,
   };
+
+  const updateResult = await runStartupUpdateCheck({
+    currentVersion: STASIUM_VERSION,
+    executablePath: process.argv[0] ?? process.execPath,
+    platform: currentUpdatePlatform(),
+  });
+  for (const message of updateResult.messages) {
+    console.error(message);
+  }
 
   if (args[0] === "init") {
     const manifestPath = resolve(process.cwd(), MANIFEST_PATH);

--- a/src/github-update-channel.test.ts
+++ b/src/github-update-channel.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import { GitHubUpdateChannel } from "./github-update-channel";
+
+describe("GitHub Update Channel", () => {
+  test("reads stable release metadata into an update decision", async () => {
+    const channel = new GitHubUpdateChannel({
+      repository: "modoterra/stasium",
+      fetchText: async (url) => ({
+        ok:
+          url ===
+          "https://github.com/modoterra/stasium/releases/latest/download/update-stable.json",
+        text: async () =>
+          JSON.stringify({
+            version: "0.2.0",
+            channel: "stable",
+            artifacts: [
+              {
+                platform: { os: "linux", arch: "x64" },
+                name: "stasium-linux-x64",
+                url: "https://example.com/stasium-linux-x64",
+                sha256: "abc123",
+              },
+            ],
+          }),
+      }),
+    });
+
+    await expect(
+      channel.check({
+        currentVersion: "0.1.0",
+        platform: { os: "linux", arch: "x64" },
+      }),
+    ).resolves.toEqual({
+      type: "update-available",
+      currentVersion: "0.1.0",
+      latestVersion: "0.2.0",
+      channel: "stable",
+      artifact: {
+        platform: { os: "linux", arch: "x64" },
+        name: "stasium-linux-x64",
+        url: "https://example.com/stasium-linux-x64",
+        sha256: "abc123",
+      },
+    });
+  });
+
+  test("reports unavailable metadata without throwing", async () => {
+    const channel = new GitHubUpdateChannel({
+      repository: "modoterra/stasium",
+      fetchText: async () => ({ ok: false, text: async () => "" }),
+    });
+
+    await expect(
+      channel.check({ currentVersion: "0.1.0", platform: { os: "linux", arch: "x64" } }),
+    ).resolves.toEqual({
+      type: "channel-unavailable",
+      currentVersion: "0.1.0",
+      channel: "stable",
+      reason: "Update metadata unavailable for channel stable.",
+    });
+  });
+
+  test("reports malformed metadata as a failure", async () => {
+    const channel = new GitHubUpdateChannel({
+      repository: "modoterra/stasium",
+      fetchText: async () => ({ ok: true, text: async () => "not json" }),
+    });
+
+    const decision = await channel.check({
+      currentVersion: "0.1.0",
+      platform: { os: "linux", arch: "x64" },
+    });
+
+    expect(decision.type).toBe("failure");
+  });
+});

--- a/src/github-update-channel.ts
+++ b/src/github-update-channel.ts
@@ -1,0 +1,77 @@
+import {
+  decideUpdate,
+  type UpdateChannelName,
+  type UpdateDecision,
+  type UpdatePlatform,
+  type UpdateRelease,
+} from "./update-channel";
+import { getErrorMessage } from "./shared";
+
+type FetchText = (
+  url: string,
+  options?: RequestInit,
+) => Promise<{ ok: boolean; text: () => Promise<string> }>;
+
+export interface GitHubUpdateChannelOptions {
+  repository: string;
+  fetchText?: FetchText;
+  metadataUrl?: string;
+}
+
+export interface CheckGitHubUpdateInput {
+  currentVersion: string;
+  channel?: UpdateChannelName;
+  platform: UpdatePlatform;
+  signal?: AbortSignal;
+}
+
+export class GitHubUpdateChannel {
+  private readonly repository: string;
+  private readonly fetchText: FetchText;
+  private readonly metadataUrl?: string;
+
+  constructor(options: GitHubUpdateChannelOptions) {
+    this.repository = options.repository;
+    this.fetchText = options.fetchText ?? fetch;
+    this.metadataUrl = options.metadataUrl;
+  }
+
+  async check(input: CheckGitHubUpdateInput): Promise<UpdateDecision> {
+    const channel = input.channel ?? "stable";
+    try {
+      const response = await this.fetchText(this.resolveMetadataUrl(channel), {
+        signal: input.signal,
+      });
+      if (!response.ok) {
+        return {
+          type: "channel-unavailable",
+          currentVersion: input.currentVersion,
+          channel,
+          reason: `Update metadata unavailable for channel ${channel}.`,
+        };
+      }
+
+      const release = JSON.parse(await response.text()) as UpdateRelease;
+      return decideUpdate({
+        currentVersion: input.currentVersion,
+        channel,
+        platform: input.platform,
+        releases: [release],
+      });
+    } catch (error) {
+      return {
+        type: "failure",
+        currentVersion: input.currentVersion,
+        channel,
+        reason: `Failed to read Update Channel: ${getErrorMessage(error)}`,
+      };
+    }
+  }
+
+  private resolveMetadataUrl(channel: UpdateChannelName): string {
+    return (
+      this.metadataUrl ??
+      `https://github.com/${this.repository}/releases/latest/download/update-${channel}.json`
+    );
+  }
+}

--- a/src/self-update.test.ts
+++ b/src/self-update.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { SelfUpdateInstaller } from "./self-update";
+
+const sha256 = (contents: string): string => createHash("sha256").update(contents).digest("hex");
+
+describe("Self Update Installer", () => {
+  test("installs a checksum-verified artifact safely", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-update-"));
+    try {
+      const executablePath = join(dir, "stasium");
+      await writeFile(executablePath, "old");
+      const installer = new SelfUpdateInstaller({
+        executablePath,
+        tempDir: join(dir, "tmp"),
+        downloadArtifact: async () => new TextEncoder().encode("new"),
+        platform: "linux",
+      });
+
+      await expect(
+        installer.install({
+          platform: { os: "linux", arch: "x64" },
+          name: "stasium-linux-x64",
+          url: "https://example.com/stasium-linux-x64",
+          sha256: sha256("new"),
+        }),
+      ).resolves.toEqual({ type: "installed", path: executablePath });
+      expect(await readFile(executablePath, "utf8")).toBe("new");
+      expect((await stat(executablePath)).mode & 0o111).toBeGreaterThan(0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects checksum mismatches before replacement", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-update-"));
+    try {
+      const executablePath = join(dir, "stasium");
+      await writeFile(executablePath, "old");
+      const installer = new SelfUpdateInstaller({
+        executablePath,
+        tempDir: join(dir, "tmp"),
+        downloadArtifact: async () => new TextEncoder().encode("new"),
+      });
+
+      await expect(
+        installer.install({
+          platform: { os: "linux", arch: "x64" },
+          name: "stasium-linux-x64",
+          url: "https://example.com/stasium-linux-x64",
+          sha256: sha256("different"),
+        }),
+      ).resolves.toEqual({
+        type: "failed",
+        reason: "Downloaded update checksum did not match metadata.",
+      });
+      expect(await readFile(executablePath, "utf8")).toBe("old");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns manual instructions when the executable cannot be inspected", async () => {
+    const installer = new SelfUpdateInstaller({
+      executablePath: "/tmp/does-not-exist-stasium",
+      tempDir: "/tmp/stasium-update-test",
+      downloadArtifact: async () => new Uint8Array(),
+    });
+
+    const result = await installer.install({
+      platform: { os: "linux", arch: "x64" },
+      name: "stasium-linux-x64",
+      url: "https://example.com/stasium-linux-x64",
+      sha256: sha256(""),
+    });
+
+    expect(result.type).toBe("manual");
+  });
+
+  test("does not replace executables that do not look like Stasium", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-update-"));
+    try {
+      const executablePath = join(dir, "bun");
+      await writeFile(executablePath, "old");
+      const installer = new SelfUpdateInstaller({
+        executablePath,
+        tempDir: join(dir, "tmp"),
+        downloadArtifact: async () => new TextEncoder().encode("new"),
+      });
+
+      await expect(
+        installer.install({
+          platform: { os: "linux", arch: "x64" },
+          name: "stasium-linux-x64",
+          url: "https://example.com/stasium-linux-x64",
+          sha256: sha256("new"),
+        }),
+      ).resolves.toEqual({
+        type: "manual",
+        reason: "Current executable does not look like a Stasium binary.",
+        url: "https://example.com/stasium-linux-x64",
+      });
+      expect(await readFile(executablePath, "utf8")).toBe("old");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/self-update.ts
+++ b/src/self-update.ts
@@ -1,0 +1,82 @@
+import { chmod, copyFile, mkdir, rename, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { createHash } from "node:crypto";
+import type { UpdateArtifact } from "./update-channel";
+import { getErrorMessage } from "./shared";
+
+type DownloadArtifact = (url: string) => Promise<Uint8Array>;
+
+export interface SelfUpdateInstallerOptions {
+  executablePath: string;
+  tempDir: string;
+  downloadArtifact?: DownloadArtifact;
+  platform?: NodeJS.Platform;
+}
+
+export type SelfUpdateResult =
+  | { type: "installed"; path: string }
+  | { type: "manual"; reason: string; url: string }
+  | { type: "failed"; reason: string };
+
+export class SelfUpdateInstaller {
+  private readonly executablePath: string;
+  private readonly tempDir: string;
+  private readonly downloadArtifact: DownloadArtifact;
+  private readonly platform: NodeJS.Platform;
+
+  constructor(options: SelfUpdateInstallerOptions) {
+    this.executablePath = options.executablePath;
+    this.tempDir = options.tempDir;
+    this.downloadArtifact = options.downloadArtifact ?? downloadWithFetch;
+    this.platform = options.platform ?? process.platform;
+  }
+
+  async install(artifact: UpdateArtifact): Promise<SelfUpdateResult> {
+    let executableStat;
+    try {
+      executableStat = await stat(this.executablePath);
+    } catch (error) {
+      return { type: "manual", reason: getErrorMessage(error), url: artifact.url };
+    }
+
+    if (!executableStat.isFile()) {
+      return { type: "manual", reason: "Current executable is not a file.", url: artifact.url };
+    }
+
+    if (!basename(this.executablePath).startsWith("stasium")) {
+      return {
+        type: "manual",
+        reason: "Current executable does not look like a Stasium binary.",
+        url: artifact.url,
+      };
+    }
+
+    try {
+      const contents = await this.downloadArtifact(artifact.url);
+      const actual = createHash("sha256").update(contents).digest("hex");
+      if (actual !== artifact.sha256) {
+        return { type: "failed", reason: "Downloaded update checksum did not match metadata." };
+      }
+
+      await mkdir(this.tempDir, { recursive: true });
+      const nextPath = join(this.tempDir, artifact.name);
+      const backupPath = join(this.tempDir, `${artifact.name}.previous`);
+      await writeFile(nextPath, contents);
+      if (this.platform !== "win32") await chmod(nextPath, 0o755);
+      await copyFile(this.executablePath, backupPath);
+      await rename(nextPath, this.executablePath);
+      return { type: "installed", path: this.executablePath };
+    } catch (error) {
+      return { type: "manual", reason: getErrorMessage(error), url: artifact.url };
+    }
+  }
+}
+
+const downloadWithFetch: DownloadArtifact = async (url) => {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Download failed with status ${response.status}`);
+  return new Uint8Array(await response.arrayBuffer());
+};
+
+export const defaultSelfUpdateTempDir = (executablePath: string): string =>
+  join(dirname(executablePath), ".stasium-update");

--- a/src/startup-update.test.ts
+++ b/src/startup-update.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runStartupUpdateCheck } from "./startup-update";
+
+describe("Startup Update Check", () => {
+  test("fails open when the Update Channel cannot be read", async () => {
+    const result = await runStartupUpdateCheck({
+      currentVersion: "0.1.0",
+      executablePath: process.execPath,
+      platform: { os: "linux", arch: "x64" },
+      checkUpdate: async () => {
+        throw new Error("network unavailable");
+      },
+    });
+
+    expect(result.messages).toEqual(["Stasium update check failed: network unavailable"]);
+  });
+
+  test("applies safe updates and reports restart guidance", async () => {
+    const result = await runStartupUpdateCheck({
+      currentVersion: "0.1.0",
+      executablePath: process.execPath,
+      platform: { os: "linux", arch: "x64" },
+      checkUpdate: async () => ({
+        type: "update-available",
+        currentVersion: "0.1.0",
+        latestVersion: "0.2.0",
+        channel: "stable",
+        artifact: {
+          platform: { os: "linux", arch: "x64" },
+          name: "stasium-linux-x64",
+          url: "https://example.com/stasium-linux-x64",
+          sha256: "abc123",
+        },
+      }),
+      installUpdate: async () => ({ type: "installed", path: "/usr/local/bin/stasium" }),
+    });
+
+    expect(result.messages).toEqual(["Updated Stasium to 0.2.0. Restart Stasium to use it."]);
+  });
+
+  test("respects disabled user preferences", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-startup-update-"));
+    try {
+      const preferencesPath = join(dir, "update.json");
+      await writeFile(preferencesPath, JSON.stringify({ enabled: false }));
+      let checked = false;
+
+      const result = await runStartupUpdateCheck({
+        currentVersion: "0.1.0",
+        executablePath: process.execPath,
+        platform: { os: "linux", arch: "x64" },
+        preferencesPath,
+        checkUpdate: async () => {
+          checked = true;
+          return { type: "up-to-date", currentVersion: "0.1.0", channel: "stable" };
+        },
+      });
+
+      expect(result.messages).toEqual([]);
+      expect(checked).toBe(false);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("fails open when user preferences are malformed", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-startup-update-"));
+    try {
+      const preferencesPath = join(dir, "update.json");
+      await writeFile(preferencesPath, "not json");
+
+      const result = await runStartupUpdateCheck({
+        currentVersion: "0.1.0",
+        executablePath: process.execPath,
+        platform: { os: "linux", arch: "x64" },
+        preferencesPath,
+        checkUpdate: async () => ({
+          type: "up-to-date",
+          currentVersion: "0.1.0",
+          channel: "stable",
+        }),
+      });
+
+      expect(result.messages[0]).toStartWith("Stasium update check failed:");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/startup-update.ts
+++ b/src/startup-update.ts
@@ -1,0 +1,101 @@
+import {
+  defaultSelfUpdateTempDir,
+  SelfUpdateInstaller,
+  type SelfUpdateResult,
+} from "./self-update";
+import { GitHubUpdateChannel } from "./github-update-channel";
+import { defaultUpdatePreferencesPath, loadUpdatePreferences } from "./update-preferences";
+import type { UpdateDecision, UpdatePlatform } from "./update-channel";
+import { getErrorMessage } from "./shared";
+
+export interface StartupUpdateCheckOptions {
+  currentVersion: string;
+  executablePath: string;
+  platform: UpdatePlatform;
+  timeoutMs?: number;
+  preferencesPath?: string;
+  checkUpdate?: (signal: AbortSignal) => Promise<UpdateDecision>;
+  installUpdate?: (
+    decision: Extract<UpdateDecision, { type: "update-available" }>,
+  ) => Promise<SelfUpdateResult>;
+}
+
+export interface StartupUpdateResult {
+  messages: string[];
+}
+
+export const runStartupUpdateCheck = async (
+  options: StartupUpdateCheckOptions,
+): Promise<StartupUpdateResult> => {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs ?? 1500);
+
+  try {
+    const preferences = await loadUpdatePreferences(
+      options.preferencesPath ?? defaultUpdatePreferencesPath(),
+    );
+    if (!preferences.enabled) return { messages: [] };
+
+    const decision = await (
+      options.checkUpdate ?? defaultUpdateCheck(options, preferences.channel)
+    )(controller.signal);
+    if (decision.type === "up-to-date") return { messages: [] };
+    if (decision.type === "update-available") {
+      const install = await (options.installUpdate ?? defaultInstall(options))(decision);
+      if (install.type === "installed") {
+        return {
+          messages: [`Updated Stasium to ${decision.latestVersion}. Restart Stasium to use it.`],
+        };
+      }
+      if (install.type === "manual") {
+        return { messages: [`Stasium ${decision.latestVersion} is available: ${install.url}`] };
+      }
+      return { messages: [`Stasium update failed: ${install.reason}`] };
+    }
+
+    if (decision.type === "unsupported-platform") {
+      return {
+        messages: [
+          `Stasium ${decision.latestVersion} is available, but no ${decision.platform.os}-${decision.platform.arch} artifact was found.`,
+        ],
+      };
+    }
+
+    return { messages: [`Stasium update skipped: ${decision.reason}`] };
+  } catch (error) {
+    return { messages: [`Stasium update check failed: ${getErrorMessage(error)}`] };
+  } finally {
+    clearTimeout(timeout);
+  }
+};
+
+const defaultUpdateCheck = (
+  options: StartupUpdateCheckOptions,
+  channel: string,
+): ((signal: AbortSignal) => Promise<UpdateDecision>) => {
+  const updateChannel = new GitHubUpdateChannel({ repository: "modoterra/stasium" });
+  return (signal) =>
+    updateChannel.check({
+      currentVersion: options.currentVersion,
+      channel,
+      platform: options.platform,
+      signal,
+    });
+};
+
+const defaultInstall = (
+  options: StartupUpdateCheckOptions,
+): ((
+  decision: Extract<UpdateDecision, { type: "update-available" }>,
+) => Promise<SelfUpdateResult>) => {
+  const installer = new SelfUpdateInstaller({
+    executablePath: options.executablePath,
+    tempDir: defaultSelfUpdateTempDir(options.executablePath),
+  });
+  return (decision) => installer.install(decision.artifact);
+};
+
+export const currentUpdatePlatform = (): UpdatePlatform => ({
+  os: process.platform === "darwin" ? "macos" : process.platform,
+  arch: process.arch,
+});

--- a/src/update-preferences.test.ts
+++ b/src/update-preferences.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { defaultUpdatePreferencesPath, loadUpdatePreferences } from "./update-preferences";
+
+describe("Update Preferences", () => {
+  test("defaults to enabled stable update checks", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-prefs-"));
+    try {
+      await expect(loadUpdatePreferences(join(dir, "missing.json"))).resolves.toEqual({
+        enabled: true,
+        channel: "stable",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("loads user opt-out and channel selection outside the Manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-prefs-"));
+    try {
+      const path = defaultUpdatePreferencesPath(dir);
+      await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, JSON.stringify({ enabled: false, channel: "nightly" }));
+
+      await expect(loadUpdatePreferences(path)).resolves.toEqual({
+        enabled: false,
+        channel: "nightly",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/update-preferences.ts
+++ b/src/update-preferences.ts
@@ -1,0 +1,28 @@
+import { join } from "node:path";
+import type { UpdateChannelName } from "./update-channel";
+
+export interface UpdatePreferences {
+  enabled: boolean;
+  channel: UpdateChannelName;
+}
+
+export const defaultUpdatePreferences: UpdatePreferences = {
+  enabled: true,
+  channel: "stable",
+};
+
+export const defaultUpdatePreferencesPath = (home = process.env.HOME ?? process.cwd()): string =>
+  join(home, ".config", "stasium", "update.json");
+
+export const loadUpdatePreferences = async (
+  path = defaultUpdatePreferencesPath(),
+): Promise<UpdatePreferences> => {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return { ...defaultUpdatePreferences };
+
+  const parsed = JSON.parse(await file.text()) as Partial<UpdatePreferences>;
+  return {
+    enabled: parsed.enabled ?? defaultUpdatePreferences.enabled,
+    channel: parsed.channel ?? defaultUpdatePreferences.channel,
+  };
+};

--- a/src/update-release-metadata.test.ts
+++ b/src/update-release-metadata.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { generateUpdateMetadata, parseChecksums } from "./update-release-metadata";
+
+describe("release update metadata", () => {
+  test("generates stable channel metadata for published release assets", () => {
+    const metadata = generateUpdateMetadata({
+      version: "v0.2.0",
+      baseUrl: "https://github.com/modoterra/stasium/releases/download/v0.2.0",
+      checksums: parseChecksums(
+        [
+          "aaa  stasium-linux-x64",
+          "bbb  stasium-linux-arm64",
+          "ccc  stasium-macos-arm64",
+          "ddd  stasium-windows-x64.exe",
+          "eee  checksums.txt",
+        ].join("\n"),
+      ),
+    });
+
+    expect(metadata).toEqual({
+      version: "0.2.0",
+      channel: "stable",
+      artifacts: [
+        {
+          platform: { os: "linux", arch: "x64" },
+          name: "stasium-linux-x64",
+          url: "https://github.com/modoterra/stasium/releases/download/v0.2.0/stasium-linux-x64",
+          sha256: "aaa",
+        },
+        {
+          platform: { os: "linux", arch: "arm64" },
+          name: "stasium-linux-arm64",
+          url: "https://github.com/modoterra/stasium/releases/download/v0.2.0/stasium-linux-arm64",
+          sha256: "bbb",
+        },
+        {
+          platform: { os: "macos", arch: "arm64" },
+          name: "stasium-macos-arm64",
+          url: "https://github.com/modoterra/stasium/releases/download/v0.2.0/stasium-macos-arm64",
+          sha256: "ccc",
+        },
+        {
+          platform: { os: "windows", arch: "x64" },
+          name: "stasium-windows-x64.exe",
+          url: "https://github.com/modoterra/stasium/releases/download/v0.2.0/stasium-windows-x64.exe",
+          sha256: "ddd",
+        },
+      ],
+    });
+  });
+});

--- a/src/update-release-metadata.ts
+++ b/src/update-release-metadata.ts
@@ -1,0 +1,52 @@
+import type { UpdateArtifact, UpdateChannelName, UpdateRelease } from "./update-channel";
+
+export interface ReleaseAssetChecksum {
+  name: string;
+  sha256: string;
+}
+
+export interface GenerateUpdateMetadataInput {
+  version: string;
+  channel?: UpdateChannelName;
+  baseUrl: string;
+  checksums: ReleaseAssetChecksum[];
+}
+
+const artifactPlatforms: Record<string, UpdateArtifact["platform"]> = {
+  "stasium-linux-x64": { os: "linux", arch: "x64" },
+  "stasium-linux-arm64": { os: "linux", arch: "arm64" },
+  "stasium-macos-arm64": { os: "macos", arch: "arm64" },
+  "stasium-windows-x64.exe": { os: "windows", arch: "x64" },
+};
+
+export const parseChecksums = (contents: string): ReleaseAssetChecksum[] =>
+  contents
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [sha256, name] = line.split(/\s+/);
+      if (!sha256 || !name) throw new Error(`Invalid checksum line: ${line}`);
+      return { name, sha256 };
+    });
+
+export const generateUpdateMetadata = (input: GenerateUpdateMetadataInput): UpdateRelease => {
+  const artifacts = input.checksums.flatMap((checksum): UpdateArtifact[] => {
+    const platform = artifactPlatforms[checksum.name];
+    if (!platform) return [];
+    return [
+      {
+        platform,
+        name: checksum.name,
+        url: `${input.baseUrl.replace(/\/$/, "")}/${checksum.name}`,
+        sha256: checksum.sha256,
+      },
+    ];
+  });
+
+  return {
+    version: input.version.replace(/^v/, ""),
+    channel: input.channel ?? "stable",
+    artifacts,
+  };
+};

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const STASIUM_VERSION = "0.1.0";


### PR DESCRIPTION
## Summary
- publish stable update metadata with release assets
- add GitHub Releases Update Channel adapter
- add checksum-verified Self Update Installer with manual fallback
- run bounded startup update checks before Project Setup or Workspace startup
- add user-level update preferences outside project Manifests
- document startup auto-update behavior

## Tests
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build

Closes #52
Closes #53
Closes #54
Closes #55
Closes #56
Closes #57
Part of #50