### PR TITLE
feat: separate process claim cleanup

### DIFF
--- a/src/manifest-editing.test.ts
+++ b/src/manifest-editing.test.ts
@@ -29,19 +29,19 @@ const launchPid = (pid: number): LaunchInstructionExecutionAdapter =>
   });
 
 class TestClaims extends ProcessClaimStore {
-  releasedNames: string[] = [];
+  cleanedUpNames: string[] = [];
 
   override async claimDirectManagedProcess(): Promise<void> {}
 
   override async releaseDirectManagedProcess(): Promise<void> {}
 
-  override async releaseDirectManagedProcessNames(names: string[]): Promise<void> {
-    this.releasedNames.push(...names);
+  override async cleanupRemovedDirectManagedProcessClaims(names: string[]): Promise<void> {
+    this.cleanedUpNames.push(...names);
   }
 }
 
 class FailingReleaseClaims extends TestClaims {
-  override async releaseDirectManagedProcessNames(): Promise<void> {
+  override async cleanupRemovedDirectManagedProcessClaims(): Promise<void> {
     throw new Error("release failed");
   }
 }
@@ -114,7 +114,7 @@ describe("Manifest Editing", () => {
     }
   });
 
-  test("replaces a Process Definition and releases the old Process Claim name", async () => {
+  test("replaces a Process Definition and cleans up the old Process Claim name", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     const manifestPath = join(dir, "stasium.toml");
     try {
@@ -138,14 +138,14 @@ describe("Manifest Editing", () => {
       const manifest = await loadManifest(manifestPath);
       expect(manager.getConfigs().map((config) => config.name)).toEqual(["web"]);
       expect(manifest.services.map((config) => config.name)).toEqual(["web"]);
-      expect(claims.releasedNames).toEqual(["api"]);
+      expect(claims.cleanedUpNames).toEqual(["api"]);
       expect(manager.getSelectedView()?.restartInMs).toBeNull();
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  test("does not replace or release claims when the Manifest cannot be saved", async () => {
+  test("does not replace or clean up claims when the Manifest cannot be saved", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     try {
       const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
@@ -162,7 +162,7 @@ describe("Manifest Editing", () => {
       ).rejects.toThrow();
 
       expect(manager.getConfigs().map((config) => config.name)).toEqual(["api"]);
-      expect(claims.releasedNames).toEqual([]);
+      expect(claims.cleanedUpNames).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -187,13 +187,15 @@ describe("Manifest Editing", () => {
       const manifest = await loadManifest(manifestPath);
       expect(manager.getConfigs().map((config) => config.name)).toEqual(["web"]);
       expect(manifest.services.map((config) => config.name)).toEqual(["web"]);
-      expect(result.warnings).toEqual(["Failed to release Process Claims: release failed"]);
+      expect(result.warnings).toEqual([
+        "Failed to clean up removed Process Claims: release failed",
+      ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
   });
 
-  test("deletes the selected Process Definition and releases its Process Claim name", async () => {
+  test("deletes the selected Process Definition and cleans up its Process Claim name", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     const manifestPath = join(dir, "stasium.toml");
     try {
@@ -207,7 +209,7 @@ describe("Manifest Editing", () => {
       const manifest = await loadManifest(manifestPath);
       expect(manager.getConfigs()).toEqual([]);
       expect(manifest.services).toEqual([]);
-      expect(claims.releasedNames).toEqual(["api"]);
+      expect(claims.cleanedUpNames).toEqual(["api"]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -24,7 +24,7 @@ export interface ManifestEditingResult {
 interface ManifestEditTransaction {
   nextConfigs: ServiceConfig[];
   apply: () => Promise<void>;
-  releaseClaimNames?: string[];
+  cleanupRemovedClaimNames?: string[];
 }
 
 export const addProcessDefinition = async (
@@ -56,7 +56,7 @@ export const replaceProcessDefinition = async (
     apply: async () => {
       await context.manager.updateServiceConfig(index, config);
     },
-    releaseClaimNames: previousName && previousName !== config.name ? [previousName] : [],
+    cleanupRemovedClaimNames: previousName && previousName !== config.name ? [previousName] : [],
   });
 };
 
@@ -73,7 +73,7 @@ export const removeSelectedProcessDefinition = async (
     apply: async () => {
       await context.manager.removeSelected();
     },
-    releaseClaimNames: removedName ? [removedName] : [],
+    cleanupRemovedClaimNames: removedName ? [removedName] : [],
   });
 };
 
@@ -119,13 +119,13 @@ const applyManifestEdit = async (
 
   const warnings: string[] = [];
 
-  if (transaction.releaseClaimNames && transaction.releaseClaimNames.length > 0) {
+  if (transaction.cleanupRemovedClaimNames && transaction.cleanupRemovedClaimNames.length > 0) {
     try {
-      await context.processClaimStore.releaseDirectManagedProcessNames(
-        transaction.releaseClaimNames,
+      await context.processClaimStore.cleanupRemovedDirectManagedProcessClaims(
+        transaction.cleanupRemovedClaimNames,
       );
     } catch (error) {
-      warnings.push(`Failed to release Process Claims: ${getErrorMessage(error)}`);
+      warnings.push(`Failed to clean up removed Process Claims: ${getErrorMessage(error)}`);
     }
   }
 

--- a/src/pidfile.test.ts
+++ b/src/pidfile.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 import { readLiveProcessInfo } from "./process-info";
-import { cleanupExistingPids, setPidDirRootForTests, syncPidFiles } from "./pidfile";
+import { cleanupExistingPids, setPidDirRootForTests, writePidFiles } from "./pidfile";
 import { normalizeProcessDefinition } from "./process-definition";
 import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager } from "./service-manager";
@@ -67,7 +67,7 @@ const spawnIdleProcess = () =>
   });
 
 describe("pidfile cleanup", () => {
-  test("syncPidFiles writes structured launch identity for running services", async () => {
+  test("writePidFiles writes structured launch identity for running services", async () => {
     if (process.platform === "win32") return;
 
     const { cwd, pidDir } = await createTestCwd();
@@ -89,7 +89,7 @@ describe("pidfile cleanup", () => {
         throw new Error("Expected running service metadata.");
       }
 
-      await syncPidFiles(cwd, manager.getServicePids());
+      await writePidFiles(cwd, manager.getServicePids());
       const contents = await readFile(resolve(pidDir, "api.pid"), "utf8");
       const parsed = JSON.parse(contents) as {
         pid: number;
@@ -108,6 +108,47 @@ describe("pidfile cleanup", () => {
       expect(parsed.identityVerified).toBe(true);
     } finally {
       await manager.stopAll();
+    }
+  });
+
+  test("cleanupExistingPids stops matching live process claims", async () => {
+    if (process.platform === "win32") return;
+
+    const { cwd, pidDir } = await createTestCwd();
+    const proc = spawnIdleProcess();
+
+    try {
+      const liveInfo = await readLiveProcessInfo(proc.pid);
+      expect(liveInfo).not.toBeNull();
+      if (!liveInfo) {
+        throw new Error("Expected live process info.");
+      }
+      await mkdir(pidDir, { recursive: true });
+      await writeFile(
+        resolve(pidDir, "api.pid"),
+        JSON.stringify({
+          version: 1,
+          pid: proc.pid,
+          service: "api",
+          cwd,
+          command: liveInfo.command
+            ? [liveInfo.command]
+            : ["bun", "-e", "setInterval(() => {}, 1000)"],
+          startedAt: liveInfo.startedAt,
+          identityVerified: true,
+          platform: process.platform,
+        }),
+      );
+
+      await cleanupExistingPids(cwd, { knownServices: ["api"] });
+
+      expect(isProcessAlive(proc.pid)).toBe(false);
+      await expect(access(resolve(pidDir, "api.pid"))).rejects.toThrow();
+    } finally {
+      if (isProcessAlive(proc.pid)) {
+        process.kill(proc.pid, "SIGKILL");
+      }
+      await proc.exited;
     }
   });
 

--- a/src/pidfile.ts
+++ b/src/pidfile.ts
@@ -316,20 +316,9 @@ export const cleanupExistingPids = async (
   }
 };
 
-type SyncOptions = {
-  knownServices?: string[];
-  logger?: (message: string) => void;
-  timeoutMs?: number;
-};
-
-export const syncPidFiles = async (
-  cwd: string,
-  services: ServicePid[],
-  { knownServices = [], logger, timeoutMs = DEFAULT_WAIT_MS }: SyncOptions = {},
-): Promise<void> => {
+export const writePidFiles = async (cwd: string, services: ServicePid[]): Promise<void> => {
   const dir = await ensurePidDir(cwd);
   const desired = new Map<string, PidFileRecord>();
-  const known = new Set(knownServices.map((name) => sanitizeServiceName(name)));
 
   for (const service of services) {
     if (!service.pid || service.pid <= 0 || service.startedAt.length === 0) continue;
@@ -350,24 +339,6 @@ export const syncPidFiles = async (
       if (pid === process.pid) return;
       if (!isProcessAlive(pid)) {
         await safeUnlink(path);
-        return;
-      }
-      const serviceName = getServiceNameFromFile(path);
-      const unknown = known.size > 0 && !known.has(serviceName);
-      if (unknown) {
-        logger?.(`Found PID ${pid} for removed service: ${serviceName}.`);
-        if (parsed.kind === "legacy" || !parsed.record.identityVerified) {
-          logger?.(`Skipping live PID ${pid}; pidfile identity cannot be verified safely.`);
-          return;
-        }
-        if (!(await liveProcessMatchesRecord(parsed.record))) {
-          logger?.(`Skipping PID ${pid}; pidfile identity no longer matches the live process.`);
-          return;
-        }
-        const stopped = await stopPid(pid, timeoutMs);
-        if (stopped) {
-          await safeUnlink(path);
-        }
         return;
       }
     }),

--- a/src/process-claim.ts
+++ b/src/process-claim.ts
@@ -2,7 +2,7 @@ import {
   cleanupExistingPids,
   removePidFilesForServices,
   removeServicePidFiles,
-  syncPidFiles,
+  writePidFiles,
 } from "./pidfile";
 import type { ServicePid } from "./types";
 
@@ -23,17 +23,14 @@ export class ProcessClaimStore {
   }
 
   async claimDirectManagedProcess(claim: ServicePid): Promise<void> {
-    await syncPidFiles(this.cwd, [claim], {
-      logger: this.logger,
-      timeoutMs: this.timeoutMs,
-    });
+    await writePidFiles(this.cwd, [claim]);
   }
 
   async releaseDirectManagedProcess(claim: ServicePid): Promise<void> {
     await removeServicePidFiles(this.cwd, [claim]);
   }
 
-  async releaseDirectManagedProcessNames(names: string[]): Promise<void> {
+  async cleanupRemovedDirectManagedProcessClaims(names: string[]): Promise<void> {
     await removePidFilesForServices(this.cwd, names);
   }
 


### PR DESCRIPTION
## Summary
- rename pidfile claim writes to make them non-destructive by default
- move removed-claim cleanup behind explicit ProcessClaimStore cleanup terminology
- keep workspace cleanup responsible for stopping matching stale claims

Fixes #62

Supersedes #64, which was stacked on the now-merged #63 branch.

## Verification
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test
- bun run build