### PR TITLE
Introduce domain-shaped Process Definition interface

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -132,6 +132,9 @@ describe("manifest rendering", () => {
         env: { PORT: "3000" },
         restart_policy: "never",
         depends_on: ["db"],
+        launchInstruction: { executable: "bun", arguments: ["run", "dev"] },
+        startupDependencies: ["db"],
+        restartRule: "never",
       });
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -7,7 +7,14 @@ import {
 } from "./process-definition";
 import { ServiceGraphError, validateServiceGraph } from "./service-graph";
 import { getErrorMessage } from "./shared";
-import type { AppConfig, AppDockerConfig, CommandSpec, Manifest, ServiceConfig } from "./types";
+import type {
+  AppConfig,
+  AppDockerConfig,
+  CommandSpec,
+  Manifest,
+  ProcessDefinition,
+  ServiceConfig,
+} from "./types";
 
 type RawManifest = {
   app?: {
@@ -193,7 +200,7 @@ export const loadManifest = async (path?: string): Promise<Manifest> => {
 
   const app = normalizeApp(parsed.app);
   const inputs = services.map((service, index) => toProcessDefinitionInput(service, index));
-  const normalized = ((): ServiceConfig[] => {
+  const normalized = ((): ProcessDefinition[] => {
     try {
       return normalizeProcessDefinitions(inputs, { baseDir: dirname(resolve(manifestPath)) });
     } catch (error) {

--- a/src/process-definition.test.ts
+++ b/src/process-definition.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { ProcessDefinitionError, normalizeProcessDefinition } from "./process-definition";
+
+describe("process definition normalization", () => {
+  test("returns a domain-shaped Process Definition", () => {
+    const definition = normalizeProcessDefinition(
+      {
+        name: " api ",
+        command: "bun run dev",
+        working_dir: "app",
+        env: { PORT: "3000" },
+        restart_policy: "on-failure",
+        depends_on: [" db "],
+      },
+      { baseDir: "/workspace" },
+    );
+
+    expect(definition).toMatchObject({
+      name: "api",
+      working_dir: resolve("/workspace", "app"),
+      env: { PORT: "3000" },
+      launchInstruction: { executable: "bun", arguments: ["run", "dev"] },
+      startupDependencies: ["db"],
+      restartRule: "on-failure",
+    });
+  });
+
+  test("preserves default Process Definition behavior", () => {
+    const definition = normalizeProcessDefinition({ name: "api", command: ["bun", "--version"] });
+
+    expect(definition).toMatchObject({
+      env: {},
+      launchInstruction: { executable: "bun", arguments: ["--version"] },
+      startupDependencies: [],
+      restartRule: "never",
+    });
+  });
+
+  test("rejects invalid Startup Dependencies", () => {
+    expect(() =>
+      normalizeProcessDefinition({ name: "api", command: ["bun", "--version"], depends_on: [""] }),
+    ).toThrow(ProcessDefinitionError);
+  });
+});

--- a/src/process-definition.ts
+++ b/src/process-definition.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { normalizeCommand } from "./command";
-import type { CommandSpec, RestartPolicy, ServiceConfig } from "./types";
+import type { CommandSpec, LaunchInstruction, ProcessDefinition, RestartPolicy } from "./types";
 
 export interface ProcessDefinitionInput {
   name: string;
@@ -54,18 +54,30 @@ const normalizeDependencies = (dependencies: string[] | undefined): string[] => 
   return normalized;
 };
 
+const toLaunchInstruction = (command: string[]): LaunchInstruction => ({
+  executable: command[0] ?? "",
+  arguments: command.slice(1),
+});
+
 export const normalizeProcessDefinition = (
   input: ProcessDefinitionInput,
   options: NormalizeProcessDefinitionOptions = {},
-): ServiceConfig => {
+): ProcessDefinition => {
   try {
+    const command = normalizeCommand(input.command);
+    const restartPolicy = input.restart_policy ?? "never";
+    const startupDependencies = normalizeDependencies(input.depends_on);
+
     return {
       name: normalizeName(input.name),
-      command: normalizeCommand(input.command),
+      command,
       working_dir: normalizeWorkingDir(input.working_dir, options.baseDir),
       env: normalizeEnv(input.env),
-      restart_policy: input.restart_policy ?? "never",
-      depends_on: normalizeDependencies(input.depends_on),
+      restart_policy: restartPolicy,
+      depends_on: startupDependencies,
+      launchInstruction: toLaunchInstruction(command),
+      startupDependencies,
+      restartRule: restartPolicy,
     };
   } catch (error) {
     if (error instanceof ProcessDefinitionError) throw error;
@@ -76,4 +88,4 @@ export const normalizeProcessDefinition = (
 export const normalizeProcessDefinitions = (
   inputs: ProcessDefinitionInput[],
   options: NormalizeProcessDefinitionOptions = {},
-): ServiceConfig[] => inputs.map((input) => normalizeProcessDefinition(input, options));
+): ProcessDefinition[] => inputs.map((input) => normalizeProcessDefinition(input, options));

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,15 @@ export type ServiceState = "STOPPED" | "STARTING" | "RUNNING" | "FAILED" | "STOP
 
 export type CommandSpec = string | string[];
 
+export interface LaunchInstruction {
+  executable: string;
+  arguments: string[];
+}
+
+export type RestartRule = RestartPolicy;
+
+export type StartupDependency = string;
+
 export interface ServiceConfig {
   name: string;
   command: string[];
@@ -11,6 +20,12 @@ export interface ServiceConfig {
   env: Record<string, string>;
   restart_policy: RestartPolicy;
   depends_on: string[];
+}
+
+export interface ProcessDefinition extends ServiceConfig {
+  launchInstruction: LaunchInstruction;
+  startupDependencies: StartupDependency[];
+  restartRule: RestartRule;
 }
 
 export interface AppDockerConfig {
@@ -23,7 +38,7 @@ export interface AppConfig {
 
 export interface Manifest {
   app?: AppConfig;
-  services: ServiceConfig[];
+  services: ProcessDefinition[];
   path: string;
 }
 


### PR DESCRIPTION
Closes #44

## Summary
- Adds explicit Process Definition domain fields for Launch Instruction, Startup Dependencies, and Restart Rule.
- Keeps existing Manifest/runtime field names available so current callers preserve behavior while follow-up issues migrate call sites.
- Adds Process Definition regression coverage for normalized domain fields, defaults, and invalid Startup Dependencies.

## Verification
- `bun test src/process-definition.test.ts src/manifest.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

## Known gaps
- Project has no `Ready to merge` status option; status will remain constrained to configured options.

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.