### PR TITLE
Centralize Startup Dependency acceptance modes

### DIFF
--- a/src/service-graph.test.ts
+++ b/src/service-graph.test.ts
@@ -73,6 +73,60 @@ describe("service graph", () => {
     expect(() => validateServiceGraph(services)).toThrow(ServiceGraphError);
   });
 
+  test("validates direct-only Startup Dependencies explicitly", () => {
+    const services: ServiceConfig[] = [
+      service({
+        name: "api",
+        command: ["bun", "run", "dev"],
+        depends_on: ["cache"],
+      }),
+    ];
+
+    expect(() =>
+      validateServiceGraph(services, {
+        startupDependencyValidation: { mode: "direct-only" },
+      }),
+    ).toThrow(ServiceGraphError);
+  });
+
+  test("accepts named cross-runtime Startup Dependencies", () => {
+    const services: ServiceConfig[] = [
+      service({
+        name: "api",
+        command: ["bun", "run", "dev"],
+        depends_on: ["docker:db"],
+      }),
+    ];
+
+    expect(() =>
+      validateServiceGraph(services, {
+        startupDependencyValidation: {
+          mode: "cross-runtime",
+          externalManagedProcessNames: ["docker:db"],
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects unresolved cross-runtime Startup Dependencies", () => {
+    const services: ServiceConfig[] = [
+      service({
+        name: "api",
+        command: ["bun", "run", "dev"],
+        depends_on: ["docker:db"],
+      }),
+    ];
+
+    expect(() =>
+      validateServiceGraph(services, {
+        startupDependencyValidation: {
+          mode: "cross-runtime",
+          externalManagedProcessNames: ["docker:cache"],
+        },
+      }),
+    ).toThrow(ServiceGraphError);
+  });
+
   test("rejects dependency cycles", () => {
     const services: ServiceConfig[] = [
       service({

--- a/src/service-graph.ts
+++ b/src/service-graph.ts
@@ -1,6 +1,14 @@
 import type { ServiceConfig } from "./types";
 
+export type StartupDependencyValidationMode = "direct-only" | "cross-runtime";
+
+export interface StartupDependencyValidation {
+  mode: StartupDependencyValidationMode;
+  externalManagedProcessNames?: Iterable<string>;
+}
+
 export interface ServiceGraphOptions {
+  startupDependencyValidation?: StartupDependencyValidation;
   allowExternalDependencies?: boolean;
 }
 
@@ -12,6 +20,20 @@ export class ServiceGraphError extends Error {
 }
 
 const dependenciesOf = (service: ServiceConfig): string[] => service.depends_on;
+
+const acceptsStartupDependency = (
+  servicesByName: Map<string, ServiceConfig>,
+  dependency: string,
+  options: ServiceGraphOptions,
+): boolean => {
+  if (servicesByName.has(dependency)) return true;
+
+  const validation = options.startupDependencyValidation;
+  if (!validation) return options.allowExternalDependencies === true;
+  if (validation.mode === "direct-only") return false;
+
+  return new Set(validation.externalManagedProcessNames ?? []).has(dependency);
+};
 
 const buildServiceMap = (services: ServiceConfig[]): Map<string, ServiceConfig> => {
   const byName = new Map<string, ServiceConfig>();
@@ -74,7 +96,7 @@ export const validateServiceGraph = (
 
   for (const service of services) {
     for (const dependency of dependenciesOf(service)) {
-      if (!servicesByName.has(dependency) && !options.allowExternalDependencies) {
+      if (!acceptsStartupDependency(servicesByName, dependency, options)) {
         throw new ServiceGraphError(
           `Service "${service.name}" depends on unknown service "${dependency}"`,
         );


### PR DESCRIPTION
Closes #69

## Summary
- Adds an explicit Startup Dependency validation interface with direct-only and cross-runtime modes.
- Preserves existing graph behavior for current callers while enabling cross-runtime validation against named External Managed Processes.
- Adds regression tests for direct-only rejection, accepted cross-runtime dependencies, and unresolved cross-runtime dependencies.

## Verification
- `bun test src/service-graph.test.ts src/startup-dependency-plan.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

## Known gaps
- Project has no `Ready to merge` status option; status will remain constrained to configured options.

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.