### PR TITLE
Cover Docker Compose through External Runtime Visibility

### DIFF
--- a/src/workspace-startup.test.ts
+++ b/src/workspace-startup.test.ts
@@ -34,6 +34,9 @@ describe("startWorkspace", () => {
         },
       });
       await session.startup;
+      expect(session.externalRuntimeManager?.getProcesses()).toEqual([externalProcess()]);
+      await session.externalRuntimeManager?.restartSelected();
+      session.externalRuntimeManager?.streamSelectedLogs();
       await session.shutdown.run();
       await session.externalRuntimeManager?.destroy();
 
@@ -42,6 +45,8 @@ describe("startWorkspace", () => {
         "mount workspace",
         "poll external runtime",
       ]);
+      expect(events).toContain("restart external process:db");
+      expect(events).toContain("stream external output:db");
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -87,8 +92,13 @@ const externalRuntime = (events: string[]): ExternalRuntime => ({
   isAvailable: (process) => process.state === "running",
   start: async () => {},
   stop: async () => {},
-  restart: async () => {},
-  streamOutput: (_name: string, _onOutput: (entry: LogEntry) => void) => null,
+  restart: async (name) => {
+    events.push(`restart external process:${name}`);
+  },
+  streamOutput: (name: string, _onOutput: (entry: LogEntry) => void) => {
+    events.push(`stream external output:${name}`);
+    return { stop: () => {} };
+  },
   destroy: async () => {},
 });
 


### PR DESCRIPTION
Closes #75

## Summary
- Adds Workspace startup regression coverage proving Docker Compose-style external runtimes surface as External Managed Process snapshots.
- Verifies selected lifecycle forwarding goes through the generic External Runtime Visibility manager.
- Verifies Process Output streaming is accessed through the same generic external runtime seam.

## Verification
- `bun test src/workspace-startup.test.ts src/external-runtime.test.ts src/docker.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

## Known gaps
- Project has no `Ready to merge` status option; status will remain constrained to configured options.

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.