### PR TITLE
Define Direct Managed Process collection interface

### DIFF
--- a/src/direct-managed-process-collection.test.ts
+++ b/src/direct-managed-process-collection.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DirectManagedProcessCollectionLifecycle,
+  type DirectManagedProcessCollection,
+} from "./direct-managed-process-collection";
+import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
+import type { ServiceConfig } from "./types";
+
+const processDefinition = (input: ProcessDefinitionInput): ServiceConfig =>
+  normalizeProcessDefinition(input);
+
+const processDefinitions = (): ServiceConfig[] => [
+  processDefinition({ name: "db", command: ["bun", "run", "db"] }),
+  processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+  processDefinition({
+    name: "worker",
+    command: ["bun", "run", "worker"],
+    depends_on: ["api"],
+  }),
+];
+
+describe("Direct Managed Process collection", () => {
+  test("exposes Startup and Shutdown ordering through a collection interface", () => {
+    const collection: DirectManagedProcessCollection = new DirectManagedProcessCollectionLifecycle(
+      processDefinitions,
+    );
+
+    expect(collection.startupOrder()).toEqual(["db", "api", "worker"]);
+    expect(collection.startupLayers()).toEqual([["db"], ["api"], ["worker"]]);
+    expect(collection.shutdownOrder()).toEqual(["worker", "api", "db"]);
+  });
+
+  test("computes collection-level start and stop orders for one Direct Managed Process", () => {
+    const collection: DirectManagedProcessCollection = new DirectManagedProcessCollectionLifecycle(
+      processDefinitions,
+    );
+
+    expect(collection.startOrderFor("worker")).toEqual(["db", "api", "worker"]);
+    expect(collection.stopOrderFor("db")).toEqual(["worker", "api", "db"]);
+  });
+
+  test("validates collection mutations before callers apply them", () => {
+    const collection: DirectManagedProcessCollection = new DirectManagedProcessCollectionLifecycle(
+      processDefinitions,
+    );
+
+    expect(() =>
+      collection.validate([
+        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+      ]),
+    ).toThrow();
+  });
+});

--- a/src/direct-managed-process-collection.ts
+++ b/src/direct-managed-process-collection.ts
@@ -6,7 +6,16 @@ export interface DirectManagedProcessCollectionLifecycleOptions {
   allowExternalDependencies?: boolean;
 }
 
-export class DirectManagedProcessCollectionLifecycle {
+export interface DirectManagedProcessCollection {
+  validate(configs: ServiceConfig[]): void;
+  startupLayers(): string[][];
+  startupOrder(): string[];
+  shutdownOrder(): string[];
+  startOrderFor(name: string): string[];
+  stopOrderFor(name: string): string[];
+}
+
+export class DirectManagedProcessCollectionLifecycle implements DirectManagedProcessCollection {
   private readonly getConfigs: () => ServiceConfig[];
   private readonly options: DirectManagedProcessCollectionLifecycleOptions;
 


### PR DESCRIPTION
Closes #81

## Summary
- Adds a named Direct Managed Process collection interface for validation and ordering behavior.
- Keeps the existing Direct Managed Process collection lifecycle behavior unchanged while making the seam explicit.
- Adds renderer-free tests for collection startup/shutdown order, scoped start/stop order, and pre-mutation validation.

## Verification
- `bun test src/direct-managed-process-collection.test.ts src/startup-dependency-plan.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

## Known gaps
- Project has no `Ready to merge` status option; status will remain constrained to configured options.

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.