### PR TITLE
Expose planned blocked Process States

### DIFF
--- a/src/startup-dependency-plan.test.ts
+++ b/src/startup-dependency-plan.test.ts
@@ -89,5 +89,6 @@ describe("Startup Dependency planning", () => {
         reason: 'Startup Dependency "api" failed to become available.',
       },
     ]);
+    expect(plan.blockedStatesFor(["db"])).toEqual(getBlockedProcessStates(plan, ["db"]));
   });
 });

--- a/src/startup-dependency-plan.ts
+++ b/src/startup-dependency-plan.ts
@@ -18,6 +18,7 @@ export interface StartupDependencyPlan {
   startupOrder: string[];
   startupLayers: string[][];
   shutdownOrder: string[];
+  blockedStatesFor: (unavailableNames: Iterable<string>) => BlockedProcessState[];
 }
 
 export interface StartupDependencyPlanOptions {
@@ -57,12 +58,14 @@ export const planStartupDependencies = (
   try {
     validateServiceGraph(cloned, options);
     const startupOrder = getTopologicalServiceOrder(cloned, options);
-    return {
+    const plan: StartupDependencyPlan = {
       processDefinitions: cloned,
       startupOrder,
       startupLayers: getTopologicalServiceLayers(cloned, options),
       shutdownOrder: [...startupOrder].reverse(),
+      blockedStatesFor: (unavailableNames) => getBlockedProcessStates(plan, unavailableNames),
     };
+    return plan;
   } catch (error) {
     toPlanningError(error);
   }


### PR DESCRIPTION
Closes #88

## Summary
- Makes blocked Process State derivation an explicit part of the Startup Dependency plan interface.
- Keeps the existing standalone helper for compatibility while routing the plan method to the same behavior.
- Adds regression coverage that the plan-owned method matches existing blocked-state derivation.

## Verification
- `bun test src/startup-dependency-plan.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

## Known gaps
- Project has no `Ready to merge` status option; status will remain constrained to configured options.

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.