### PR TITLE
Keep Manifest field names inside adapter boundary

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -266,7 +266,7 @@ const setupKeybindings = (
       try {
         await addProcessDefinition(
           { manifestPath, appConfig, manager, processClaimStore },
-          { name, command },
+          { name, launchInstruction: command },
         );
         controls.hideAddOverlay();
         focusManager.setMode("normal");

--- a/src/direct-managed-process-collection.test.ts
+++ b/src/direct-managed-process-collection.test.ts
@@ -10,12 +10,16 @@ const processDefinition = (input: ProcessDefinitionInput): ServiceConfig =>
   normalizeProcessDefinition(input);
 
 const processDefinitions = (): ServiceConfig[] => [
-  processDefinition({ name: "db", command: ["bun", "run", "db"] }),
-  processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+  processDefinition({ name: "db", launchInstruction: ["bun", "run", "db"] }),
+  processDefinition({
+    name: "api",
+    launchInstruction: ["bun", "run", "dev"],
+    startupDependencies: ["db"],
+  }),
   processDefinition({
     name: "worker",
-    command: ["bun", "run", "worker"],
-    depends_on: ["api"],
+    launchInstruction: ["bun", "run", "worker"],
+    startupDependencies: ["api"],
   }),
 ];
 
@@ -46,7 +50,11 @@ describe("Direct Managed Process collection", () => {
 
     expect(() =>
       collection.validate([
-        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+        processDefinition({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["db"],
+        }),
       ]),
     ).toThrow();
   });

--- a/src/discovery/engine.ts
+++ b/src/discovery/engine.ts
@@ -181,11 +181,11 @@ const buildCandidateService = (
 
   const input: ProcessDefinitionInput = {
     name: renderedName,
-    command: renderedCommand,
-    working_dir: renderedWorkingDir,
-    env: renderedEnv,
-    restart_policy: strategy.service.restart_policy,
-    depends_on: renderedDependsOn,
+    launchInstruction: renderedCommand,
+    workingDir: renderedWorkingDir,
+    environment: renderedEnv,
+    restartRule: strategy.service.restart_policy,
+    startupDependencies: renderedDependsOn,
   };
 
   try {

--- a/src/discovery/selection.test.ts
+++ b/src/discovery/selection.test.ts
@@ -16,7 +16,7 @@ const makeCandidate = (
   dependsOnIds,
   service: normalizeProcessDefinition({
     name,
-    command: ["bun", "run", "dev"],
+    launchInstruction: ["bun", "run", "dev"],
   }),
 });
 
@@ -101,8 +101,8 @@ describe("discovery selection", () => {
           ...makeCandidate("api", "api"),
           service: normalizeProcessDefinition({
             name: "api",
-            command: ["bun", "run", "dev"],
-            depends_on: ["missing"],
+            launchInstruction: ["bun", "run", "dev"],
+            startupDependencies: ["missing"],
           }),
         },
       ]),
@@ -116,8 +116,8 @@ describe("discovery selection", () => {
           ...makeCandidate("api", "api"),
           service: normalizeProcessDefinition({
             name: "api",
-            command: ["bun", "run", "dev"],
-            depends_on: ["db"],
+            launchInstruction: ["bun", "run", "dev"],
+            startupDependencies: ["db"],
           }),
         },
       ],
@@ -125,7 +125,7 @@ describe("discovery selection", () => {
         existingServices: [
           normalizeProcessDefinition({
             name: "db",
-            command: ["bun", "run", "db"],
+            launchInstruction: ["bun", "run", "db"],
           }),
         ],
         usedNames: ["db"],

--- a/src/manifest-editing.test.ts
+++ b/src/manifest-editing.test.ts
@@ -60,7 +60,7 @@ describe("Manifest Editing", () => {
 
       await addProcessDefinition(
         { manifestPath, manager, processClaimStore: claims },
-        { name: "api", command: "bun run dev" },
+        { name: "api", launchInstruction: "bun run dev" },
       );
 
       const manifest = await loadManifest(manifestPath);
@@ -83,7 +83,7 @@ describe("Manifest Editing", () => {
       await expect(
         addProcessDefinition(
           { manifestPath, manager, processClaimStore: claims },
-          { name: "api", command: "bun run dev", depends_on: ["missing"] },
+          { name: "api", launchInstruction: "bun run dev", startupDependencies: ["missing"] },
         ),
       ).rejects.toThrow('depends on unknown service "missing"');
 
@@ -104,7 +104,7 @@ describe("Manifest Editing", () => {
       await expect(
         addProcessDefinition(
           { manifestPath: dir, manager, processClaimStore: claims },
-          { name: "api", command: "bun run dev" },
+          { name: "api", launchInstruction: "bun run dev" },
         ),
       ).rejects.toThrow();
 
@@ -118,7 +118,10 @@ describe("Manifest Editing", () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     const manifestPath = join(dir, "stasium.toml");
     try {
-      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      const original = normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: "bun run dev",
+      });
       await saveManifest(manifestPath, [original]);
       const claims = new TestClaims(dir);
       const manager = new ServiceManager([original], {
@@ -128,7 +131,10 @@ describe("Manifest Editing", () => {
       const view = manager.getSelectedView();
       if (view) view.restartInMs = 123;
 
-      const replacement = normalizeProcessDefinition({ name: "web", command: "bun run dev" });
+      const replacement = normalizeProcessDefinition({
+        name: "web",
+        launchInstruction: "bun run dev",
+      });
       await replaceProcessDefinition(
         { manifestPath, manager, processClaimStore: claims },
         0,
@@ -148,10 +154,16 @@ describe("Manifest Editing", () => {
   test("does not replace or clean up claims when the Manifest cannot be saved", async () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     try {
-      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      const original = normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: "bun run dev",
+      });
       const claims = new TestClaims(dir);
       const manager = new ServiceManager([original], { processClaimStore: claims });
-      const replacement = normalizeProcessDefinition({ name: "web", command: "bun run dev" });
+      const replacement = normalizeProcessDefinition({
+        name: "web",
+        launchInstruction: "bun run dev",
+      });
 
       await expect(
         replaceProcessDefinition(
@@ -172,11 +184,17 @@ describe("Manifest Editing", () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     const manifestPath = join(dir, "stasium.toml");
     try {
-      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      const original = normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: "bun run dev",
+      });
       await saveManifest(manifestPath, [original]);
       const claims = new FailingReleaseClaims(dir);
       const manager = new ServiceManager([original], { processClaimStore: claims });
-      const replacement = normalizeProcessDefinition({ name: "web", command: "bun run dev" });
+      const replacement = normalizeProcessDefinition({
+        name: "web",
+        launchInstruction: "bun run dev",
+      });
 
       const result = await replaceProcessDefinition(
         { manifestPath, manager, processClaimStore: claims },
@@ -199,7 +217,10 @@ describe("Manifest Editing", () => {
     const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
     const manifestPath = join(dir, "stasium.toml");
     try {
-      const original = normalizeProcessDefinition({ name: "api", command: "bun run dev" });
+      const original = normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: "bun run dev",
+      });
       await saveManifest(manifestPath, [original]);
       const claims = new TestClaims(dir);
       const manager = new ServiceManager([original], { processClaimStore: claims });

--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -27,8 +27,8 @@ describe("manifest rendering", () => {
     const { manifestPath, dir } = await writeTempManifest([
       {
         name: "api",
-        command: ["bun", "run", "dev"],
-        env: { "APP.CONFIG": "on" },
+        launchInstruction: ["bun", "run", "dev"],
+        environment: { "APP.CONFIG": "on" },
       },
     ]);
 
@@ -44,13 +44,13 @@ describe("manifest rendering", () => {
     const { manifestPath, dir } = await writeTempManifest([
       {
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["worker"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["worker"],
       },
       {
         name: "worker",
-        command: ["bun", "run", "worker"],
-        depends_on: ["api"],
+        launchInstruction: ["bun", "run", "worker"],
+        startupDependencies: ["api"],
       },
     ]);
 
@@ -121,17 +121,14 @@ describe("manifest rendering", () => {
       const manifest = await loadManifest(manifestPath);
       expect(manifest.services[0]).toMatchObject({
         name: "db",
-        env: {},
-        restart_policy: "never",
-        depends_on: [],
+        environment: {},
+        restartRule: "never",
+        startupDependencies: [],
       });
-      expect(manifest.services[1]).toEqual({
+      expect(manifest.services[1]).toMatchObject({
         name: "api",
-        command: ["bun", "run", "dev"],
-        working_dir: resolve(dir, "app"),
-        env: { PORT: "3000" },
-        restart_policy: "never",
-        depends_on: ["db"],
+        workingDir: resolve(dir, "app"),
+        environment: { PORT: "3000" },
         launchInstruction: { executable: "bun", arguments: ["run", "dev"] },
         startupDependencies: ["db"],
         restartRule: "never",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -163,11 +163,11 @@ const toProcessDefinitionInput = (raw: RawServiceConfig, index: number): Process
 
   return {
     name: raw.name,
-    command: raw.command as CommandSpec,
-    working_dir: raw.working_dir,
-    env,
-    restart_policy: raw.restart_policy as ProcessDefinitionInput["restart_policy"],
-    depends_on: raw.depends_on,
+    launchInstruction: raw.command as CommandSpec,
+    workingDir: raw.working_dir,
+    environment: env,
+    restartRule: raw.restart_policy as ProcessDefinitionInput["restartRule"],
+    startupDependencies: raw.depends_on,
   };
 };
 

--- a/src/pidfile.test.ts
+++ b/src/pidfile.test.ts
@@ -74,7 +74,7 @@ describe("pidfile cleanup", () => {
     const manager = new ServiceManager([
       normalizeProcessDefinition({
         name: "api",
-        command: ["bun", "-e", "setInterval(() => {}, 1000)"],
+        launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
       }),
     ]);
 
@@ -219,13 +219,13 @@ describe("pidfile cleanup", () => {
       [
         normalizeProcessDefinition({
           name: "app",
-          command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-          working_dir: cwd,
+          launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
+          workingDir: cwd,
         }),
         normalizeProcessDefinition({
           name: "frontend",
-          command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-          working_dir: cwd,
+          launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
+          workingDir: cwd,
         }),
       ],
       { processClaimStore: new ProcessClaimStore(cwd) },

--- a/src/process-definition.test.ts
+++ b/src/process-definition.test.ts
@@ -7,19 +7,19 @@ describe("process definition normalization", () => {
     const definition = normalizeProcessDefinition(
       {
         name: " api ",
-        command: "bun run dev",
-        working_dir: "app",
-        env: { PORT: "3000" },
-        restart_policy: "on-failure",
-        depends_on: [" db "],
+        launchInstruction: "bun run dev",
+        workingDir: "app",
+        environment: { PORT: "3000" },
+        restartRule: "on-failure",
+        startupDependencies: [" db "],
       },
       { baseDir: "/workspace" },
     );
 
     expect(definition).toMatchObject({
       name: "api",
-      working_dir: resolve("/workspace", "app"),
-      env: { PORT: "3000" },
+      workingDir: resolve("/workspace", "app"),
+      environment: { PORT: "3000" },
       launchInstruction: { executable: "bun", arguments: ["run", "dev"] },
       startupDependencies: ["db"],
       restartRule: "on-failure",
@@ -27,10 +27,13 @@ describe("process definition normalization", () => {
   });
 
   test("preserves default Process Definition behavior", () => {
-    const definition = normalizeProcessDefinition({ name: "api", command: ["bun", "--version"] });
+    const definition = normalizeProcessDefinition({
+      name: "api",
+      launchInstruction: ["bun", "--version"],
+    });
 
     expect(definition).toMatchObject({
-      env: {},
+      environment: {},
       launchInstruction: { executable: "bun", arguments: ["--version"] },
       startupDependencies: [],
       restartRule: "never",
@@ -39,7 +42,11 @@ describe("process definition normalization", () => {
 
   test("rejects invalid Startup Dependencies", () => {
     expect(() =>
-      normalizeProcessDefinition({ name: "api", command: ["bun", "--version"], depends_on: [""] }),
+      normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: ["bun", "--version"],
+        startupDependencies: [""],
+      }),
     ).toThrow(ProcessDefinitionError);
   });
 });

--- a/src/process-definition.ts
+++ b/src/process-definition.ts
@@ -4,11 +4,11 @@ import type { CommandSpec, LaunchInstruction, ProcessDefinition, RestartPolicy }
 
 export interface ProcessDefinitionInput {
   name: string;
-  command: CommandSpec;
-  working_dir?: string;
-  env?: Record<string, string>;
-  restart_policy?: RestartPolicy;
-  depends_on?: string[];
+  launchInstruction: CommandSpec;
+  workingDir?: string;
+  environment?: Record<string, string>;
+  restartRule?: RestartPolicy;
+  startupDependencies?: string[];
 }
 
 export interface NormalizeProcessDefinitionOptions {
@@ -64,18 +64,22 @@ export const normalizeProcessDefinition = (
   options: NormalizeProcessDefinitionOptions = {},
 ): ProcessDefinition => {
   try {
-    const command = normalizeCommand(input.command);
-    const restartPolicy = input.restart_policy ?? "never";
-    const startupDependencies = normalizeDependencies(input.depends_on);
+    const command = normalizeCommand(input.launchInstruction);
+    const workingDir = normalizeWorkingDir(input.workingDir, options.baseDir);
+    const environment = normalizeEnv(input.environment);
+    const restartPolicy = input.restartRule ?? "never";
+    const startupDependencies = normalizeDependencies(input.startupDependencies);
 
     return {
       name: normalizeName(input.name),
       command,
-      working_dir: normalizeWorkingDir(input.working_dir, options.baseDir),
-      env: normalizeEnv(input.env),
+      working_dir: workingDir,
+      env: environment,
       restart_policy: restartPolicy,
       depends_on: startupDependencies,
       launchInstruction: toLaunchInstruction(command),
+      workingDir,
+      environment,
       startupDependencies,
       restartRule: restartPolicy,
     };

--- a/src/project-setup.test.ts
+++ b/src/project-setup.test.ts
@@ -32,7 +32,7 @@ describe("createProjectManifest", () => {
         label: "Node",
         priority: 10,
         defaultSelected: true,
-        service: normalizeProcessDefinition({ name: "web", command: "bun run dev" }),
+        service: normalizeProcessDefinition({ name: "web", launchInstruction: "bun run dev" }),
         dependsOnIds: [],
       };
       const selection = new DiscoverySelection([candidate]);

--- a/src/service-graph.test.ts
+++ b/src/service-graph.test.ts
@@ -15,17 +15,17 @@ const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProce
 const baseServices: ServiceConfig[] = [
   service({
     name: "api",
-    command: ["bun", "run", "dev"],
-    depends_on: ["db"],
+    launchInstruction: ["bun", "run", "dev"],
+    startupDependencies: ["db"],
   }),
   service({
     name: "db",
-    command: ["docker", "compose", "up", "db"],
+    launchInstruction: ["docker", "compose", "up", "db"],
   }),
   service({
     name: "worker",
-    command: ["bun", "run", "worker"],
-    depends_on: ["api"],
+    launchInstruction: ["bun", "run", "worker"],
+    startupDependencies: ["api"],
   }),
 ];
 
@@ -38,9 +38,13 @@ describe("service graph", () => {
     expect(getTopologicalServiceLayers(baseServices)).toEqual([["db"], ["api"], ["worker"]]);
     expect(
       getTopologicalServiceLayers([
-        service({ name: "db", command: ["bun", "--version"] }),
-        service({ name: "cache", command: ["bun", "--version"] }),
-        service({ name: "api", command: ["bun", "--version"], depends_on: ["db", "cache"] }),
+        service({ name: "db", launchInstruction: ["bun", "--version"] }),
+        service({ name: "cache", launchInstruction: ["bun", "--version"] }),
+        service({
+          name: "api",
+          launchInstruction: ["bun", "--version"],
+          startupDependencies: ["db", "cache"],
+        }),
       ]),
     ).toEqual([["db", "cache"], ["api"]]);
   });
@@ -65,8 +69,8 @@ describe("service graph", () => {
     const services: ServiceConfig[] = [
       service({
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["cache"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["cache"],
       }),
     ];
 
@@ -77,8 +81,8 @@ describe("service graph", () => {
     const services: ServiceConfig[] = [
       service({
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["cache"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["cache"],
       }),
     ];
 
@@ -93,8 +97,8 @@ describe("service graph", () => {
     const services: ServiceConfig[] = [
       service({
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["docker:db"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["docker:db"],
       }),
     ];
 
@@ -112,8 +116,8 @@ describe("service graph", () => {
     const services: ServiceConfig[] = [
       service({
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["docker:db"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["docker:db"],
       }),
     ];
 
@@ -131,13 +135,13 @@ describe("service graph", () => {
     const services: ServiceConfig[] = [
       service({
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["worker"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["worker"],
       }),
       service({
         name: "worker",
-        command: ["bun", "run", "worker"],
-        depends_on: ["api"],
+        launchInstruction: ["bun", "run", "worker"],
+        startupDependencies: ["api"],
       }),
     ];
 

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -11,7 +11,7 @@ const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProce
 const makeConfig = (name: string): ServiceConfig =>
   service({
     name,
-    command: ["bun", "--version"],
+    launchInstruction: ["bun", "--version"],
   });
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -104,12 +104,12 @@ describe("ServiceManager", () => {
     const manager = new ServiceManager([
       service({
         name: "db",
-        command: ["bun", "-e", "setTimeout(() => process.exit(0), 400)"],
+        launchInstruction: ["bun", "-e", "setTimeout(() => process.exit(0), 400)"],
       }),
       service({
         name: "api",
-        command: ["bun", "-e", "setTimeout(() => process.exit(0), 400)"],
-        depends_on: ["db"],
+        launchInstruction: ["bun", "-e", "setTimeout(() => process.exit(0), 400)"],
+        startupDependencies: ["db"],
       }),
     ]);
 
@@ -143,8 +143,8 @@ describe("ServiceManager", () => {
       [
         service({
           name: "api",
-          command: ["bun", "run", "dev"],
-          depends_on: ["db"],
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["db"],
         }),
       ],
       {
@@ -171,8 +171,8 @@ describe("ServiceManager", () => {
       [
         service({
           name: "api",
-          command: ["bun", "run", "dev"],
-          depends_on: ["db"],
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["db"],
         }),
       ],
       { externalRuntimeManager, launchAdapter: launchLongRunningPid(21) },
@@ -189,12 +189,12 @@ describe("ServiceManager", () => {
     const manager = new ServiceManager([
       service({
         name: "db",
-        command: ["bun", "-e", "setInterval(() => {}, 1000)"],
+        launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
       }),
       service({
         name: "api",
-        command: ["bun", "-e", "setInterval(() => {}, 1000)"],
-        depends_on: ["db"],
+        launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
+        startupDependencies: ["db"],
       }),
     ]);
 
@@ -219,7 +219,7 @@ describe("ServiceManager", () => {
     const manager = new ServiceManager([
       service({
         name: "stubborn",
-        command: ["bun", "-e", stubbornScript],
+        launchInstruction: ["bun", "-e", stubbornScript],
       }),
     ]);
 
@@ -244,7 +244,7 @@ describe("ServiceManager", () => {
     const manager = new ServiceManager([
       service({
         name: "tree",
-        command: ["bun", "-e", parentScript],
+        launchInstruction: ["bun", "-e", parentScript],
       }),
     ]);
 
@@ -291,8 +291,8 @@ describe("ServiceManager", () => {
     const manager = new ServiceManager([
       service({
         name: "failing",
-        command: ["bun", "-e", "process.exit(1)"],
-        restart_policy: "on-failure",
+        launchInstruction: ["bun", "-e", "process.exit(1)"],
+        restartRule: "on-failure",
       }),
     ]);
 
@@ -343,12 +343,12 @@ describe("ServiceManager", () => {
       [
         service({
           name: "db",
-          command: ["missing"],
+          launchInstruction: ["missing"],
         }),
         service({
           name: "api",
-          command: ["bun", "run", "dev"],
-          depends_on: ["db"],
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["db"],
         }),
       ],
       { launchAdapter },
@@ -367,7 +367,7 @@ describe("ServiceManager", () => {
     const manager = new ServiceManager([
       service({
         name: "api",
-        command: ["bun", "-e", "setInterval(() => {}, 1000)"],
+        launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
       }),
     ]);
 
@@ -391,22 +391,25 @@ describe("ServiceManager", () => {
       }
     }
 
-    const manager = new ServiceManager([service({ name: "api", command: ["bun", "run", "dev"] })], {
-      processClaimStore: new TestClaims(process.cwd()),
-      launchAdapter: new LaunchInstructionExecutionAdapter({
-        now: () => "now",
-        pathReader: async () => process.env.PATH ?? "",
-        processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
-        spawner: () => ({
-          pid: 10,
-          stdout: null,
-          stderr: null,
-          exited: new Promise(() => {}),
-          signalCode: null,
-          kill: () => {},
+    const manager = new ServiceManager(
+      [service({ name: "api", launchInstruction: ["bun", "run", "dev"] })],
+      {
+        processClaimStore: new TestClaims(process.cwd()),
+        launchAdapter: new LaunchInstructionExecutionAdapter({
+          now: () => "now",
+          pathReader: async () => process.env.PATH ?? "",
+          processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+          spawner: () => ({
+            pid: 10,
+            stdout: null,
+            stderr: null,
+            exited: new Promise(() => {}),
+            signalCode: null,
+            kill: () => {},
+          }),
         }),
-      }),
-    });
+      },
+    );
     manager.onProcessChange(() => {
       if (manager.getSelectedView()?.state === "RUNNING") events.push("running");
     });
@@ -424,22 +427,25 @@ describe("ServiceManager", () => {
       }
     }
 
-    const manager = new ServiceManager([service({ name: "api", command: ["bun", "run", "dev"] })], {
-      processClaimStore: new FailingClaims(process.cwd()),
-      launchAdapter: new LaunchInstructionExecutionAdapter({
-        now: () => "now",
-        pathReader: async () => process.env.PATH ?? "",
-        processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
-        spawner: () => ({
-          pid: 11,
-          stdout: null,
-          stderr: null,
-          exited: new Promise(() => {}),
-          signalCode: null,
-          kill: (signal) => killed.push(signal),
+    const manager = new ServiceManager(
+      [service({ name: "api", launchInstruction: ["bun", "run", "dev"] })],
+      {
+        processClaimStore: new FailingClaims(process.cwd()),
+        launchAdapter: new LaunchInstructionExecutionAdapter({
+          now: () => "now",
+          pathReader: async () => process.env.PATH ?? "",
+          processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+          spawner: () => ({
+            pid: 11,
+            stdout: null,
+            stderr: null,
+            exited: new Promise(() => {}),
+            signalCode: null,
+            kill: (signal) => killed.push(signal),
+          }),
         }),
-      }),
-    });
+      },
+    );
 
     await manager.startAll();
 
@@ -457,22 +463,25 @@ describe("ServiceManager", () => {
       }
     }
 
-    const manager = new ServiceManager([service({ name: "api", command: ["bun", "run", "dev"] })], {
-      processClaimStore: new TestClaims(process.cwd()),
-      launchAdapter: new LaunchInstructionExecutionAdapter({
-        now: () => "now",
-        pathReader: async () => process.env.PATH ?? "",
-        processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
-        spawner: () => ({
-          pid: 12,
-          stdout: null,
-          stderr: null,
-          exited: Promise.resolve(0),
-          signalCode: null,
-          kill: () => {},
+    const manager = new ServiceManager(
+      [service({ name: "api", launchInstruction: ["bun", "run", "dev"] })],
+      {
+        processClaimStore: new TestClaims(process.cwd()),
+        launchAdapter: new LaunchInstructionExecutionAdapter({
+          now: () => "now",
+          pathReader: async () => process.env.PATH ?? "",
+          processInfoReader: async (pid) => ({ pid, startedAt: "started", command: null }),
+          spawner: () => ({
+            pid: 12,
+            stdout: null,
+            stderr: null,
+            exited: Promise.resolve(0),
+            signalCode: null,
+            kill: () => {},
+          }),
         }),
-      }),
-    });
+      },
+    );
 
     await manager.startAll();
     await waitFor(() => released.length === 1);

--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -30,11 +30,11 @@ describe("ServiceManager launch execution", () => {
       [
         normalizeProcessDefinition({
           name: "api",
-          command: ["bun", "run", "dev"],
+          launchInstruction: ["bun", "run", "dev"],
         }),
         normalizeProcessDefinition({
           name: "worker",
-          command: ["bun", "run", "worker"],
+          launchInstruction: ["bun", "run", "worker"],
         }),
       ],
       { launchAdapter },

--- a/src/startup-dependency-plan.test.ts
+++ b/src/startup-dependency-plan.test.ts
@@ -13,12 +13,16 @@ const processDefinition = (input: ProcessDefinitionInput): ServiceConfig =>
 describe("Startup Dependency planning", () => {
   test("computes Startup order and reverse Shutdown order", () => {
     const plan = planStartupDependencies([
-      processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
-      processDefinition({ name: "db", command: ["bun", "run", "db"] }),
+      processDefinition({
+        name: "api",
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["db"],
+      }),
+      processDefinition({ name: "db", launchInstruction: ["bun", "run", "db"] }),
       processDefinition({
         name: "worker",
-        command: ["bun", "run", "worker"],
-        depends_on: ["api"],
+        launchInstruction: ["bun", "run", "worker"],
+        startupDependencies: ["api"],
       }),
     ]);
 
@@ -30,30 +34,42 @@ describe("Startup Dependency planning", () => {
   test("validates duplicate names, unknown dependencies, self-dependencies, and cycles", () => {
     expect(() =>
       planStartupDependencies([
-        processDefinition({ name: "api", command: ["bun", "run", "dev"] }),
-        processDefinition({ name: "api", command: ["bun", "run", "worker"] }),
+        processDefinition({ name: "api", launchInstruction: ["bun", "run", "dev"] }),
+        processDefinition({ name: "api", launchInstruction: ["bun", "run", "worker"] }),
       ]),
     ).toThrow(StartupDependencyPlanError);
 
     expect(() =>
       planStartupDependencies([
-        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["db"] }),
+        processDefinition({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["db"],
+        }),
       ]),
     ).toThrow(StartupDependencyPlanError);
 
     expect(() =>
       planStartupDependencies([
-        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["api"] }),
+        processDefinition({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["api"],
+        }),
       ]),
     ).toThrow(StartupDependencyPlanError);
 
     expect(() =>
       planStartupDependencies([
-        processDefinition({ name: "api", command: ["bun", "run", "dev"], depends_on: ["worker"] }),
+        processDefinition({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["worker"],
+        }),
         processDefinition({
           name: "worker",
-          command: ["bun", "run", "worker"],
-          depends_on: ["api"],
+          launchInstruction: ["bun", "run", "worker"],
+          startupDependencies: ["api"],
         }),
       ]),
     ).toThrow(StartupDependencyPlanError);
@@ -61,17 +77,17 @@ describe("Startup Dependency planning", () => {
 
   test("represents blocked Process State when Startup Dependencies fail", () => {
     const plan = planStartupDependencies([
-      processDefinition({ name: "db", command: ["bun", "run", "db"] }),
-      processDefinition({ name: "cache", command: ["bun", "run", "cache"] }),
+      processDefinition({ name: "db", launchInstruction: ["bun", "run", "db"] }),
+      processDefinition({ name: "cache", launchInstruction: ["bun", "run", "cache"] }),
       processDefinition({
         name: "api",
-        command: ["bun", "run", "dev"],
-        depends_on: ["db", "cache"],
+        launchInstruction: ["bun", "run", "dev"],
+        startupDependencies: ["db", "cache"],
       }),
       processDefinition({
         name: "worker",
-        command: ["bun", "run", "worker"],
-        depends_on: ["api"],
+        launchInstruction: ["bun", "run", "worker"],
+        startupDependencies: ["api"],
       }),
     ]);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface ServiceConfig {
 
 export interface ProcessDefinition extends ServiceConfig {
   launchInstruction: LaunchInstruction;
+  workingDir: string;
+  environment: Record<string, string>;
   startupDependencies: StartupDependency[];
   restartRule: RestartRule;
 }

--- a/src/workspace-startup.test.ts
+++ b/src/workspace-startup.test.ts
@@ -59,7 +59,7 @@ describe("startWorkspace", () => {
       await saveManifest(manifestPath, [
         normalizeProcessDefinition({
           name: "api",
-          command: ["bun", "-e", "setInterval(() => {}, 1000)"],
+          launchInstruction: ["bun", "-e", "setInterval(() => {}, 1000)"],
         }),
       ]);
 


### PR DESCRIPTION
Closes #45

## Summary
- Moves Process Definition normalization input to domain vocabulary: Launch Instruction, working directory, environment, Restart Rule, and Startup Dependencies.
- Keeps Manifest/TOML storage field names mapped inside the Manifest Adapter while preserving existing Manifest syntax and rendering.
- Updates tests and call sites that construct Process Definition inputs to use the domain-shaped interface.

## Verification
- `bun test src/process-definition.test.ts src/manifest.test.ts src/discovery/selection.test.ts src/discovery/engine.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.