### PR TITLE
Move runtime callers to Process Definition vocabulary

### DIFF
--- a/src/direct-managed-process-collection.test.ts
+++ b/src/direct-managed-process-collection.test.ts
@@ -4,12 +4,12 @@ import {
   type DirectManagedProcessCollection,
 } from "./direct-managed-process-collection";
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
-const processDefinition = (input: ProcessDefinitionInput): ServiceConfig =>
+const processDefinition = (input: ProcessDefinitionInput): ProcessDefinition =>
   normalizeProcessDefinition(input);
 
-const processDefinitions = (): ServiceConfig[] => [
+const processDefinitions = (): ProcessDefinition[] => [
   processDefinition({ name: "db", launchInstruction: ["bun", "run", "db"] }),
   processDefinition({
     name: "api",

--- a/src/direct-managed-process-collection.ts
+++ b/src/direct-managed-process-collection.ts
@@ -1,13 +1,13 @@
 import { getDependencyClosure, getDependentsClosure } from "./service-graph";
 import { planStartupDependencies } from "./startup-dependency-plan";
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
 export interface DirectManagedProcessCollectionLifecycleOptions {
   allowExternalDependencies?: boolean;
 }
 
 export interface DirectManagedProcessCollection {
-  validate(configs: ServiceConfig[]): void;
+  validate(configs: ProcessDefinition[]): void;
   startupLayers(): string[][];
   startupOrder(): string[];
   shutdownOrder(): string[];
@@ -16,18 +16,18 @@ export interface DirectManagedProcessCollection {
 }
 
 export class DirectManagedProcessCollectionLifecycle implements DirectManagedProcessCollection {
-  private readonly getConfigs: () => ServiceConfig[];
+  private readonly getConfigs: () => ProcessDefinition[];
   private readonly options: DirectManagedProcessCollectionLifecycleOptions;
 
   constructor(
-    getConfigs: () => ServiceConfig[],
+    getConfigs: () => ProcessDefinition[],
     options: DirectManagedProcessCollectionLifecycleOptions = {},
   ) {
     this.getConfigs = getConfigs;
     this.options = options;
   }
 
-  validate(configs: ServiceConfig[]): void {
+  validate(configs: ProcessDefinition[]): void {
     planStartupDependencies(configs, this.options);
   }
 

--- a/src/direct-managed-process-lifecycle.ts
+++ b/src/direct-managed-process-lifecycle.ts
@@ -1,7 +1,7 @@
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
 export interface RestartRuleLifecycleView {
-  config: ServiceConfig;
+  config: ProcessDefinition;
   restartCount: number;
   restartInMs: number | null;
 }
@@ -82,8 +82,8 @@ export class DirectManagedProcessLifecycle {
       return;
     }
 
-    if (view.config.restart_policy === "never") return;
-    if (view.config.restart_policy === "on-failure" && exitCode === 0) return;
+    if (view.config.restartRule === "never") return;
+    if (view.config.restartRule === "on-failure" && exitCode === 0) return;
 
     const attempt = this.restartAttempts + 1;
     this.restartAttempts = attempt;

--- a/src/discovery/engine.ts
+++ b/src/discovery/engine.ts
@@ -1,5 +1,5 @@
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "../process-definition";
-import type { CommandSpec, ServiceConfig } from "../types";
+import type { CommandSpec, ProcessDefinition } from "../types";
 import { resolveStrategyCaptures } from "./captures";
 import { DiscoveryProbeContext } from "./probes";
 import type { DetectResult, DetectedCandidate, DiscoveryStrategy, StrategyWhen } from "./types";
@@ -88,7 +88,7 @@ const matchesWhen = async (when: StrategyWhen, ctx: DiscoveryProbeContext): Prom
 };
 
 type ServiceBuildResult = {
-  service: ServiceConfig | null;
+  service: ProcessDefinition | null;
   dependsOnIds: string[];
   error: string | null;
 };
@@ -205,7 +205,7 @@ const buildCandidateService = (
 
 const toCandidate = (
   strategy: DiscoveryStrategy,
-  service: ServiceConfig,
+  service: ProcessDefinition,
   dependsOnIds: string[],
 ): DetectedCandidate => {
   return {

--- a/src/discovery/selection.ts
+++ b/src/discovery/selection.ts
@@ -1,11 +1,11 @@
 import { ServiceGraphError, validateServiceGraph } from "../service-graph";
-import type { ServiceConfig } from "../types";
+import type { ProcessDefinition } from "../types";
 import type { DetectedCandidate, FinalizeSelectionResult, SelectionItem } from "./types";
 
 export type DiscoverySelectionUpdateCallback = () => void;
 
 interface FinalizeSelectionOptions {
-  existingServices?: ServiceConfig[];
+  existingServices?: ProcessDefinition[];
   usedNames?: Iterable<string>;
 }
 
@@ -16,7 +16,7 @@ export class CandidateSelectionError extends Error {
   }
 }
 
-const cloneService = (service: ServiceConfig): ServiceConfig => {
+const cloneService = (service: ProcessDefinition): ProcessDefinition => {
   return {
     name: service.name,
     command: [...service.command],
@@ -24,6 +24,11 @@ const cloneService = (service: ServiceConfig): ServiceConfig => {
     env: { ...service.env },
     restart_policy: service.restart_policy,
     depends_on: [...service.depends_on],
+    launchInstruction: { ...service.launchInstruction },
+    workingDir: service.workingDir,
+    environment: { ...service.environment },
+    restartRule: service.restartRule,
+    startupDependencies: [...service.startupDependencies],
   };
 };
 
@@ -126,7 +131,7 @@ export const finalizeSelectedCandidates = (
   options: FinalizeSelectionOptions = {},
 ): FinalizeSelectionResult => {
   const warnings: string[] = [];
-  const services: ServiceConfig[] = [];
+  const services: ProcessDefinition[] = [];
   const finalNameByStrategy = new Map<string, string>();
   const usedNames = new Set(options.usedNames ?? []);
 
@@ -148,7 +153,7 @@ export const finalizeSelectedCandidates = (
     const service = services[index];
     if (!service) return;
 
-    const resolved = [...service.depends_on];
+    const resolved = [...service.startupDependencies];
     const seen = new Set(resolved);
 
     for (const dependencyId of candidate.dependsOnIds) {
@@ -170,6 +175,7 @@ export const finalizeSelectedCandidates = (
     }
 
     service.depends_on = resolved;
+    service.startupDependencies = resolved;
   });
 
   try {

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -1,4 +1,4 @@
-import type { CommandSpec, RestartPolicy, ServiceConfig } from "../types";
+import type { CommandSpec, ProcessDefinition, RestartPolicy } from "../types";
 
 export interface ValuePathProbe {
   file: string;
@@ -78,7 +78,7 @@ export interface DetectedCandidate {
   label: string;
   priority: number;
   defaultSelected: boolean;
-  service: ServiceConfig;
+  service: ProcessDefinition;
   dependsOnIds: string[];
 }
 
@@ -93,6 +93,6 @@ export interface SelectionItem {
 }
 
 export interface FinalizeSelectionResult {
-  services: ServiceConfig[];
+  services: ProcessDefinition[];
   warnings: string[];
 }

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -7,7 +7,7 @@ import type { ProcessClaimStore } from "./process-claim";
 import { getTopologicalServiceOrder } from "./service-graph";
 import type { ServiceManager } from "./service-manager";
 import { getErrorMessage } from "./shared";
-import type { AppConfig, ServiceConfig } from "./types";
+import type { AppConfig, ProcessDefinition } from "./types";
 
 export interface ManifestEditingContext {
   manifestPath: string;
@@ -17,12 +17,12 @@ export interface ManifestEditingContext {
 }
 
 export interface ManifestEditingResult {
-  services: ServiceConfig[];
+  services: ProcessDefinition[];
   warnings: string[];
 }
 
 interface ManifestEditTransaction {
-  nextConfigs: ServiceConfig[];
+  nextConfigs: ProcessDefinition[];
   apply: () => Promise<void>;
   cleanupRemovedClaimNames?: string[];
 }
@@ -132,6 +132,6 @@ const applyManifestEdit = async (
   return { services: context.manager.getConfigs(), warnings };
 };
 
-const validateNextCollection = (services: ServiceConfig[]): void => {
+const validateNextCollection = (services: ProcessDefinition[]): void => {
   new DirectManagedProcessCollectionLifecycle(() => services).validate(services);
 };

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -291,7 +291,7 @@ export const renderServiceBlock = (service: ServiceConfig): string => {
   return renderServiceToml(service);
 };
 
-export const parseServiceBlock = (toml: string, baseDir?: string): ServiceConfig => {
+export const parseServiceBlock = (toml: string, baseDir?: string): ProcessDefinition => {
   let parsed: RawManifest;
   try {
     parsed = Bun.TOML.parse(toml) as RawManifest;

--- a/src/service-graph.test.ts
+++ b/src/service-graph.test.ts
@@ -8,11 +8,12 @@ import {
   getTopologicalServiceOrder,
   validateServiceGraph,
 } from "./service-graph";
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
-const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProcessDefinition(input);
+const service = (input: ProcessDefinitionInput): ProcessDefinition =>
+  normalizeProcessDefinition(input);
 
-const baseServices: ServiceConfig[] = [
+const baseServices: ProcessDefinition[] = [
   service({
     name: "api",
     launchInstruction: ["bun", "run", "dev"],
@@ -66,7 +67,7 @@ describe("service graph", () => {
   });
 
   test("rejects unknown dependencies", () => {
-    const services: ServiceConfig[] = [
+    const services: ProcessDefinition[] = [
       service({
         name: "api",
         launchInstruction: ["bun", "run", "dev"],
@@ -78,7 +79,7 @@ describe("service graph", () => {
   });
 
   test("validates direct-only Startup Dependencies explicitly", () => {
-    const services: ServiceConfig[] = [
+    const services: ProcessDefinition[] = [
       service({
         name: "api",
         launchInstruction: ["bun", "run", "dev"],
@@ -94,7 +95,7 @@ describe("service graph", () => {
   });
 
   test("accepts named cross-runtime Startup Dependencies", () => {
-    const services: ServiceConfig[] = [
+    const services: ProcessDefinition[] = [
       service({
         name: "api",
         launchInstruction: ["bun", "run", "dev"],
@@ -113,7 +114,7 @@ describe("service graph", () => {
   });
 
   test("rejects unresolved cross-runtime Startup Dependencies", () => {
-    const services: ServiceConfig[] = [
+    const services: ProcessDefinition[] = [
       service({
         name: "api",
         launchInstruction: ["bun", "run", "dev"],
@@ -132,7 +133,7 @@ describe("service graph", () => {
   });
 
   test("rejects dependency cycles", () => {
-    const services: ServiceConfig[] = [
+    const services: ProcessDefinition[] = [
       service({
         name: "api",
         launchInstruction: ["bun", "run", "dev"],

--- a/src/service-graph.ts
+++ b/src/service-graph.ts
@@ -1,4 +1,4 @@
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
 export type StartupDependencyValidationMode = "direct-only" | "cross-runtime";
 
@@ -19,10 +19,10 @@ export class ServiceGraphError extends Error {
   }
 }
 
-const dependenciesOf = (service: ServiceConfig): string[] => service.depends_on;
+const dependenciesOf = (service: ProcessDefinition): string[] => service.startupDependencies;
 
 const acceptsStartupDependency = (
-  servicesByName: Map<string, ServiceConfig>,
+  servicesByName: Map<string, ProcessDefinition>,
   dependency: string,
   options: ServiceGraphOptions,
 ): boolean => {
@@ -35,8 +35,8 @@ const acceptsStartupDependency = (
   return new Set(validation.externalManagedProcessNames ?? []).has(dependency);
 };
 
-const buildServiceMap = (services: ServiceConfig[]): Map<string, ServiceConfig> => {
-  const byName = new Map<string, ServiceConfig>();
+const buildServiceMap = (services: ProcessDefinition[]): Map<string, ProcessDefinition> => {
+  const byName = new Map<string, ProcessDefinition>();
 
   for (const service of services) {
     if (byName.has(service.name)) {
@@ -48,7 +48,7 @@ const buildServiceMap = (services: ServiceConfig[]): Map<string, ServiceConfig> 
   return byName;
 };
 
-const findCycle = (servicesByName: Map<string, ServiceConfig>): string[] | null => {
+const findCycle = (servicesByName: Map<string, ProcessDefinition>): string[] | null => {
   const visiting = new Set<string>();
   const visited = new Set<string>();
   const stack: string[] = [];
@@ -89,7 +89,7 @@ const findCycle = (servicesByName: Map<string, ServiceConfig>): string[] | null 
 };
 
 export const validateServiceGraph = (
-  services: ServiceConfig[],
+  services: ProcessDefinition[],
   options: ServiceGraphOptions = {},
 ): void => {
   const servicesByName = buildServiceMap(services);
@@ -114,7 +114,7 @@ export const validateServiceGraph = (
 };
 
 export const getTopologicalServiceOrder = (
-  services: ServiceConfig[],
+  services: ProcessDefinition[],
   options: ServiceGraphOptions = {},
 ): string[] => {
   validateServiceGraph(services, options);
@@ -165,7 +165,7 @@ export const getTopologicalServiceOrder = (
 };
 
 export const getTopologicalServiceLayers = (
-  services: ServiceConfig[],
+  services: ProcessDefinition[],
   options: ServiceGraphOptions = {},
 ): string[][] => {
   validateServiceGraph(services, options);
@@ -220,7 +220,7 @@ export const getTopologicalServiceLayers = (
 };
 
 export const getDependencyClosure = (
-  services: ServiceConfig[],
+  services: ProcessDefinition[],
   target: string,
   options: ServiceGraphOptions = {},
 ): Set<string> => {
@@ -250,7 +250,7 @@ export const getDependencyClosure = (
 };
 
 export const getDependentsClosure = (
-  services: ServiceConfig[],
+  services: ProcessDefinition[],
   target: string,
   options: ServiceGraphOptions = {},
 ): Set<string> => {

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -4,11 +4,12 @@ import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
 import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager, ServiceManagerError } from "./service-manager";
-import type { ExternalManagedProcess, LogEntry, ServiceConfig, ServicePid } from "./types";
+import type { ExternalManagedProcess, LogEntry, ProcessDefinition, ServicePid } from "./types";
 
-const service = (input: ProcessDefinitionInput): ServiceConfig => normalizeProcessDefinition(input);
+const service = (input: ProcessDefinitionInput): ProcessDefinition =>
+  normalizeProcessDefinition(input);
 
-const makeConfig = (name: string): ServiceConfig =>
+const makeConfig = (name: string): ProcessDefinition =>
   service({
     name,
     launchInstruction: ["bun", "--version"],

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -7,7 +7,7 @@ import { ProcessClaimStore } from "./process-claim";
 import { type ServiceEvent, ServiceProcess } from "./service";
 import { ServiceGraphError } from "./service-graph";
 import { StartupDependencyPlanError } from "./startup-dependency-plan";
-import type { ServiceConfig, ServicePid, ServiceState } from "./types";
+import type { ProcessDefinition, ServicePid, ServiceState } from "./types";
 
 export interface ServiceView {
   name: string;
@@ -17,7 +17,7 @@ export interface ServiceView {
   manualRestartCount: number;
   restartInMs: number | null;
   log: LogBuffer;
-  config: ServiceConfig;
+  config: ProcessDefinition;
 }
 
 export type UpdateCallback = () => void;
@@ -52,7 +52,7 @@ export class ServiceManager {
   private readonly processCallbacks: Set<UpdateCallback> = new Set();
   private selectedIndex = 0;
 
-  constructor(configs: ServiceConfig[], options: ServiceManagerOptions = {}) {
+  constructor(configs: ProcessDefinition[], options: ServiceManagerOptions = {}) {
     this.launchAdapter = options.launchAdapter ?? new LaunchInstructionExecutionAdapter();
     this.processClaimStore = options.processClaimStore ?? null;
     this.externalRuntimeManager = options.externalRuntimeManager ?? null;
@@ -116,12 +116,12 @@ export class ServiceManager {
     return this.views[this.selectedIndex] ?? null;
   }
 
-  getSelectedConfig(): ServiceConfig | null {
+  getSelectedConfig(): ProcessDefinition | null {
     const view = this.views[this.selectedIndex];
     return view ? view.config : null;
   }
 
-  getConfigs(): ServiceConfig[] {
+  getConfigs(): ProcessDefinition[] {
     return this.views.map((v) => v.config);
   }
 
@@ -222,7 +222,7 @@ export class ServiceManager {
     }
   }
 
-  async addService(config: ServiceConfig): Promise<void> {
+  async addService(config: ProcessDefinition): Promise<void> {
     if (this.hasServiceName(config.name)) {
       throw new ServiceManagerError(`Service name already exists: ${config.name}`);
     }
@@ -277,7 +277,7 @@ export class ServiceManager {
     return true;
   }
 
-  async updateServiceConfig(index: number, config: ServiceConfig): Promise<void> {
+  async updateServiceConfig(index: number, config: ProcessDefinition): Promise<void> {
     const oldService = this.services[index];
     if (!oldService) return;
 
@@ -392,7 +392,7 @@ export class ServiceManager {
     }
   }
 
-  private assertValidConfigGraph(configs: ServiceConfig[]): void {
+  private assertValidConfigGraph(configs: ProcessDefinition[]): void {
     this.runGraphOperation(() => {
       this.collectionLifecycle.validate(configs);
     });
@@ -462,9 +462,9 @@ export class ServiceManager {
     await this.startService(service);
   }
 
-  private async getUnavailableDependencies(config: ServiceConfig): Promise<string[]> {
+  private async getUnavailableDependencies(config: ProcessDefinition): Promise<string[]> {
     const blocked: string[] = [];
-    for (const dependency of config.depends_on) {
+    for (const dependency of config.startupDependencies) {
       const view = this.views.find((entry) => entry.name === dependency);
       if (view) {
         if (view.state === "FAILED" || view.state === "BLOCKED") blocked.push(dependency);

--- a/src/service.ts
+++ b/src/service.ts
@@ -5,7 +5,7 @@ import {
 } from "./launch-execution";
 import { resolveRuntimeWorkingDir } from "./process-info";
 import { ProcessClaimStore } from "./process-claim";
-import type { LogEntry, ServiceConfig, ServicePid, ServiceState } from "./types";
+import type { LogEntry, ProcessDefinition, ServicePid, ServiceState } from "./types";
 
 export type ServiceEvent =
   | { type: "state"; state: ServiceState }
@@ -18,7 +18,7 @@ type ServiceSubscriber = (event: ServiceEvent) => void;
 const SHOULD_DETACH_PROCESS_GROUP = process.platform !== "win32";
 
 export class ServiceProcess {
-  readonly config: ServiceConfig;
+  readonly config: ProcessDefinition;
   private readonly detached = SHOULD_DETACH_PROCESS_GROUP;
   private readonly workingDir: string;
   private readonly launchAdapter: LaunchInstructionExecutionAdapter;
@@ -35,12 +35,12 @@ export class ServiceProcess {
   private activeClaim: ServicePid | null = null;
 
   constructor(
-    config: ServiceConfig,
+    config: ProcessDefinition,
     launchAdapter = new LaunchInstructionExecutionAdapter(),
     processClaimStore: ProcessClaimStore | null = null,
   ) {
     this.config = config;
-    this.workingDir = resolveRuntimeWorkingDir(config.working_dir);
+    this.workingDir = resolveRuntimeWorkingDir(config.workingDir);
     this.launchAdapter = launchAdapter;
     this.processClaimStore = processClaimStore;
   }
@@ -92,13 +92,16 @@ export class ServiceProcess {
     this.activeClaim = null;
     this.setState("STARTING");
 
-    const argv = this.config.command;
+    const argv = [
+      this.config.launchInstruction.executable,
+      ...this.config.launchInstruction.arguments,
+    ];
     this.command = [...argv];
     const launchHandle = await this.launchAdapter.start(
       {
         argv,
         workingDir: this.workingDir,
-        env: this.config.env,
+        env: this.config.environment,
         detached: this.detached,
       },
       (event) => this.handleLaunchEvent(event),

--- a/src/startup-dependency-plan.test.ts
+++ b/src/startup-dependency-plan.test.ts
@@ -5,9 +5,9 @@ import {
   getBlockedProcessStates,
   planStartupDependencies,
 } from "./startup-dependency-plan";
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
-const processDefinition = (input: ProcessDefinitionInput): ServiceConfig =>
+const processDefinition = (input: ProcessDefinitionInput): ProcessDefinition =>
   normalizeProcessDefinition(input);
 
 describe("Startup Dependency planning", () => {

--- a/src/startup-dependency-plan.ts
+++ b/src/startup-dependency-plan.ts
@@ -4,7 +4,7 @@ import {
   getTopologicalServiceOrder,
   validateServiceGraph,
 } from "./service-graph";
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
 export type BlockedProcessState = {
   name: string;
@@ -14,7 +14,7 @@ export type BlockedProcessState = {
 };
 
 export interface StartupDependencyPlan {
-  processDefinitions: ServiceConfig[];
+  processDefinitions: ProcessDefinition[];
   startupOrder: string[];
   startupLayers: string[][];
   shutdownOrder: string[];
@@ -39,7 +39,7 @@ const toPlanningError = (error: unknown): never => {
   throw error;
 };
 
-const cloneProcessDefinitions = (processDefinitions: ServiceConfig[]): ServiceConfig[] =>
+const cloneProcessDefinitions = (processDefinitions: ProcessDefinition[]): ProcessDefinition[] =>
   processDefinitions.map((processDefinition) => ({
     name: processDefinition.name,
     command: [...processDefinition.command],
@@ -47,10 +47,15 @@ const cloneProcessDefinitions = (processDefinitions: ServiceConfig[]): ServiceCo
     env: { ...processDefinition.env },
     restart_policy: processDefinition.restart_policy,
     depends_on: [...processDefinition.depends_on],
+    launchInstruction: { ...processDefinition.launchInstruction },
+    workingDir: processDefinition.workingDir,
+    environment: { ...processDefinition.environment },
+    startupDependencies: [...processDefinition.startupDependencies],
+    restartRule: processDefinition.restartRule,
   }));
 
 export const planStartupDependencies = (
-  processDefinitions: ServiceConfig[],
+  processDefinitions: ProcessDefinition[],
   options: StartupDependencyPlanOptions = {},
 ): StartupDependencyPlan => {
   const cloned = cloneProcessDefinitions(processDefinitions);
@@ -88,7 +93,7 @@ export const getBlockedProcessStates = (
     const processDefinition = byName.get(name);
     if (!processDefinition) continue;
 
-    const blockedBy = processDefinition.depends_on.filter((dependency) =>
+    const blockedBy = processDefinition.startupDependencies.filter((dependency) =>
       unavailable.has(dependency),
     );
     if (blockedBy.length === 0) continue;


### PR DESCRIPTION
Closes #46

## Summary
- Updates runtime-facing orchestration to type against Process Definitions instead of storage-shaped ServiceConfig boundaries.
- Reads Launch Instruction, Startup Dependencies, Restart Rule, working directory, and environment through the domain-shaped Process Definition fields.
- Preserves runtime behavior and compatibility aliases for Manifest rendering and persisted Process Claims.

## Verification
- `bun test src/service-manager.test.ts src/service.test.ts src/startup-dependency-plan.test.ts src/service-graph.test.ts src/discovery/selection.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.