### PR TITLE
Assert Discovery handoff uses Process Definition interface

### DIFF
--- a/src/discovery/engine.test.ts
+++ b/src/discovery/engine.test.ts
@@ -66,11 +66,14 @@ describe("discovery engine", () => {
       const detected = await detectDiscoveryCandidates(dir, [strategy]);
       expect(detected.warnings).toHaveLength(0);
       expect(detected.candidates).toHaveLength(1);
-      expect(detected.candidates[0]?.service.command).toEqual(["bun", "run", "vite"]);
-      expect(detected.candidates[0]?.service.working_dir).toBe(resolve(dir));
-      expect(detected.candidates[0]?.service.env).toEqual({});
-      expect(detected.candidates[0]?.service.restart_policy).toBe("never");
-      expect(detected.candidates[0]?.service.depends_on).toEqual([]);
+      expect(detected.candidates[0]?.service.launchInstruction).toEqual({
+        executable: "bun",
+        arguments: ["run", "vite"],
+      });
+      expect(detected.candidates[0]?.service.workingDir).toBe(resolve(dir));
+      expect(detected.candidates[0]?.service.environment).toEqual({});
+      expect(detected.candidates[0]?.service.restartRule).toBe("never");
+      expect(detected.candidates[0]?.service.startupDependencies).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -250,22 +253,22 @@ app = FastAPI()
 
       expect(byId.has("laravel-queue")).toBe(true);
       expect(byId.has("laravel-horizon")).toBe(true);
-      expect(byId.get("laravel-horizon")?.service.command).toEqual(["php", "artisan", "horizon"]);
-      expect(byId.get("laravel-reverb")?.service.command).toEqual([
-        "php",
-        "artisan",
-        "reverb:start",
-      ]);
-      expect(byId.get("laravel-octane")?.service.command).toEqual([
-        "php",
-        "artisan",
-        "octane:start",
-      ]);
-      expect(byId.get("laravel-pulse-check")?.service.command).toEqual([
-        "php",
-        "artisan",
-        "pulse:check",
-      ]);
+      expect(byId.get("laravel-horizon")?.service.launchInstruction).toEqual({
+        executable: "php",
+        arguments: ["artisan", "horizon"],
+      });
+      expect(byId.get("laravel-reverb")?.service.launchInstruction).toEqual({
+        executable: "php",
+        arguments: ["artisan", "reverb:start"],
+      });
+      expect(byId.get("laravel-octane")?.service.launchInstruction).toEqual({
+        executable: "php",
+        arguments: ["artisan", "octane:start"],
+      });
+      expect(byId.get("laravel-pulse-check")?.service.launchInstruction).toEqual({
+        executable: "php",
+        arguments: ["artisan", "pulse:check"],
+      });
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/discovery/selection.test.ts
+++ b/src/discovery/selection.test.ts
@@ -47,7 +47,7 @@ describe("discovery selection", () => {
 
     expect(finalized.services[0]?.name).toBe("app");
     expect(finalized.services[1]?.name).toBe("app-2");
-    expect(finalized.services[1]?.depends_on).toEqual(["app"]);
+    expect(finalized.services[1]?.startupDependencies).toEqual(["app"]);
     expect(finalized.warnings).toContain("Candidate 'worker' was renamed from 'app' to 'app-2'.");
   });
 
@@ -90,7 +90,7 @@ describe("discovery selection", () => {
       makeCandidate("worker", "worker", true, ["app"]),
     ]);
 
-    expect(finalized.services[0]?.depends_on).toEqual([]);
+    expect(finalized.services[0]?.startupDependencies).toEqual([]);
     expect(finalized.warnings).toEqual([]);
   });
 
@@ -132,6 +132,6 @@ describe("discovery selection", () => {
       },
     );
 
-    expect(finalized.services[0]?.depends_on).toEqual(["db"]);
+    expect(finalized.services[0]?.startupDependencies).toEqual(["db"]);
   });
 });


### PR DESCRIPTION
Closes #47

## Summary
- Updates Discovery engine tests to assert candidate services through domain-shaped Process Definition fields.
- Updates Candidate Selection tests to assert Candidate Dependencies become Startup Dependencies.
- Keeps Discovery strategy internals and user-visible warnings/duplicate-name behavior unchanged.

## Verification
- `bun test src/discovery/selection.test.ts src/discovery/engine.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.