### PR TITLE
Rename public Process Definition boundaries

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -8,7 +8,7 @@ import {
 import type { DetectResult as DiscoveryDetectResult } from "./discovery";
 import { saveManifest } from "./manifest";
 import { formatCommandSpec } from "./shared";
-import type { AppConfig, ServiceConfig } from "./types";
+import type { AppConfig, ProcessDefinition } from "./types";
 
 export type DetectResult = DiscoveryDetectResult;
 
@@ -26,18 +26,21 @@ export const detectServices = async (cwd: string): Promise<DetectResult> => {
 
 export const getDefaultServices = (
   detected: DetectResult,
-): { services: ServiceConfig[]; warnings: string[] } => {
+): { services: ProcessDefinition[]; warnings: string[] } => {
   const defaults = detected.candidates.filter((candidate) => candidate.defaultSelected);
   return finalizeSelectedCandidates(defaults);
 };
 
 export const writeManifest = async (
   manifestPath: string,
-  services: ServiceConfig[],
+  services: ProcessDefinition[],
   app?: AppConfig,
 ): Promise<void> => {
   await saveManifest(manifestPath, services, app);
 };
 
-export const formatServiceSummary = (service: ServiceConfig): string =>
-  `${service.name}: ${formatCommandSpec(service.command)}`;
+export const formatServiceSummary = (processDefinition: ProcessDefinition): string =>
+  `${processDefinition.name}: ${formatCommandSpec([
+    processDefinition.launchInstruction.executable,
+    ...processDefinition.launchInstruction.arguments,
+  ])}`;

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -54,7 +54,7 @@ export const replaceProcessDefinition = async (
   return applyManifestEdit(context, {
     nextConfigs,
     apply: async () => {
-      await context.manager.updateServiceConfig(index, config);
+      await context.manager.updateProcessDefinition(index, config);
     },
     cleanupRemovedClaimNames: previousName && previousName !== config.name ? [previousName] : [],
   });

--- a/src/project-setup.ts
+++ b/src/project-setup.ts
@@ -1,9 +1,9 @@
 import { finalizeSelection, type DiscoverySelection } from "./discovery";
 import { writeManifest } from "./init";
-import type { ServiceConfig } from "./types";
+import type { ProcessDefinition } from "./types";
 
 export interface ProjectSetupResult {
-  services: ServiceConfig[];
+  services: ProcessDefinition[];
   warnings: string[];
 }
 

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -96,7 +96,7 @@ describe("ServiceManager", () => {
 
   test("rejects duplicate names when editing services", async () => {
     const manager = new ServiceManager([makeConfig("api"), makeConfig("worker")]);
-    await expect(manager.updateServiceConfig(0, makeConfig("worker"))).rejects.toThrow(
+    await expect(manager.updateProcessDefinition(0, makeConfig("worker"))).rejects.toThrow(
       ServiceManagerError,
     );
   });

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -277,7 +277,7 @@ export class ServiceManager {
     return true;
   }
 
-  async updateServiceConfig(index: number, config: ProcessDefinition): Promise<void> {
+  async updateProcessDefinition(index: number, config: ProcessDefinition): Promise<void> {
     const oldService = this.services[index];
     if (!oldService) return;
 


### PR DESCRIPTION
Closes #48

## Summary
- Renames the ServiceManager edit boundary to `updateProcessDefinition`.
- Moves Project Setup and init helper type boundaries to Process Definition terminology.
- Keeps storage-shaped ServiceConfig compatibility confined to Manifest rendering/parsing and the compatibility type.

## Verification
- `bun test src/service-manager.test.ts src/project-setup.test.ts src/discovery/selection.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.