### PR TITLE
Add Process Definition regression coverage

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -175,4 +175,24 @@ describe("manifest rendering", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("rejects unresolved Startup Dependencies at the Manifest Adapter boundary", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
+    const manifestPath = join(dir, "stasium.toml");
+    await Bun.write(
+      manifestPath,
+      [
+        "[[service]]",
+        'name = "api"',
+        'command = ["bun", "run", "dev"]',
+        'depends_on = ["missing"]',
+      ].join("\n"),
+    );
+
+    try {
+      await expect(loadManifest(manifestPath)).rejects.toThrow(ManifestError);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/process-definition.test.ts
+++ b/src/process-definition.test.ts
@@ -33,6 +33,7 @@ describe("process definition normalization", () => {
     });
 
     expect(definition).toMatchObject({
+      workingDir: resolve(process.cwd(), "."),
       environment: {},
       launchInstruction: { executable: "bun", arguments: ["--version"] },
       startupDependencies: [],
@@ -46,6 +47,15 @@ describe("process definition normalization", () => {
         name: "api",
         launchInstruction: ["bun", "--version"],
         startupDependencies: [""],
+      }),
+    ).toThrow(ProcessDefinitionError);
+  });
+
+  test("rejects invalid Launch Instructions before runtime callers see them", () => {
+    expect(() =>
+      normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: "bun run api && bun run worker",
       }),
     ).toThrow(ProcessDefinitionError);
   });


### PR DESCRIPTION
Closes #49

## Summary
- Adds default Process Definition behavior coverage for working directory normalization.
- Adds invalid Launch Instruction regression coverage before runtime callers receive definitions.
- Adds Manifest Adapter coverage for unresolved Startup Dependency rejection while preserving TOML syntax.

## Verification
- `bun test src/process-definition.test.ts src/manifest.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.