### PR TITLE
Accept cross-runtime Startup Dependencies in Manifest loading

### DIFF
--- a/src/manifest.test.ts
+++ b/src/manifest.test.ts
@@ -195,4 +195,28 @@ describe("manifest rendering", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  test("accepts Startup Dependencies satisfied by External Runtime Visibility", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-manifest-"));
+    const manifestPath = join(dir, "stasium.toml");
+    await Bun.write(
+      manifestPath,
+      [
+        "[[service]]",
+        'name = "api"',
+        'command = ["bun", "run", "dev"]',
+        'depends_on = ["docker:db"]',
+      ].join("\n"),
+    );
+
+    try {
+      const manifest = await loadManifest(manifestPath, {
+        externalManagedProcessNames: ["docker:db"],
+      });
+
+      expect(manifest.services[0]?.startupDependencies).toEqual(["docker:db"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -43,6 +43,10 @@ export class ManifestError extends Error {
   }
 }
 
+export interface LoadManifestOptions {
+  externalManagedProcessNames?: Iterable<string>;
+}
+
 const validServiceKeys = new Set([
   "name",
   "command",
@@ -178,7 +182,10 @@ const toManifestError = (error: unknown): never => {
   throw error;
 };
 
-export const loadManifest = async (path?: string): Promise<Manifest> => {
+export const loadManifest = async (
+  path?: string,
+  options: LoadManifestOptions = {},
+): Promise<Manifest> => {
   const manifestPath = path ?? DEFAULT_MANIFEST;
   const file = Bun.file(manifestPath);
   if (!(await file.exists())) {
@@ -210,7 +217,14 @@ export const loadManifest = async (path?: string): Promise<Manifest> => {
   })();
 
   try {
-    validateServiceGraph(normalized);
+    validateServiceGraph(normalized, {
+      startupDependencyValidation: options.externalManagedProcessNames
+        ? {
+            mode: "cross-runtime",
+            externalManagedProcessNames: options.externalManagedProcessNames,
+          }
+        : { mode: "direct-only" },
+    });
   } catch (error) {
     toManifestError(error);
   }


### PR DESCRIPTION
Closes #70

## Summary
- Adds Manifest loading options for External Managed Process names supplied by External Runtime Visibility.
- Uses the shared Startup Dependency validation interface to distinguish direct-only and cross-runtime validation.
- Keeps default Manifest loading direct-only and preserves existing unresolved dependency rejection.

## Verification
- `bun test src/manifest.test.ts src/service-graph.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.