### PR TITLE
Validate cross-runtime Startup Dependencies in Manifest Editing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -233,7 +233,7 @@ const setupKeybindings = (
       const toml = controls.getEditContent();
       try {
         await replaceProcessDefinition(
-          { manifestPath, appConfig, manager, processClaimStore },
+          { manifestPath, appConfig, manager, processClaimStore, externalRuntimeManager },
           manager.getSelectedIndex(),
           toml,
         );
@@ -265,7 +265,7 @@ const setupKeybindings = (
 
       try {
         await addProcessDefinition(
-          { manifestPath, appConfig, manager, processClaimStore },
+          { manifestPath, appConfig, manager, processClaimStore, externalRuntimeManager },
           { name, launchInstruction: command },
         );
         controls.hideAddOverlay();
@@ -325,7 +325,7 @@ const setupKeybindings = (
         try {
           const previousCount = manager.getConfigs().length;
           const result = await addSelectedDiscoveryCandidates(
-            { manifestPath, appConfig, manager, processClaimStore },
+            { manifestPath, appConfig, manager, processClaimStore, externalRuntimeManager },
             selection,
           );
 
@@ -358,6 +358,7 @@ const setupKeybindings = (
         appConfig,
         manager,
         processClaimStore,
+        externalRuntimeManager,
       });
       deleteConfirming = false;
       controls.hideDeleteConfirm();

--- a/src/direct-managed-process-collection.ts
+++ b/src/direct-managed-process-collection.ts
@@ -1,8 +1,11 @@
 import { getDependencyClosure, getDependentsClosure } from "./service-graph";
-import { planStartupDependencies } from "./startup-dependency-plan";
+import {
+  planStartupDependencies,
+  type StartupDependencyPlanOptions,
+} from "./startup-dependency-plan";
 import type { ProcessDefinition } from "./types";
 
-export interface DirectManagedProcessCollectionLifecycleOptions {
+export interface DirectManagedProcessCollectionLifecycleOptions extends StartupDependencyPlanOptions {
   allowExternalDependencies?: boolean;
 }
 

--- a/src/manifest-editing.test.ts
+++ b/src/manifest-editing.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LaunchInstructionExecutionAdapter } from "./launch-execution";
+import { ExternalRuntimeVisibilityManager, type ExternalRuntime } from "./external-runtime";
 import {
   addProcessDefinition,
   removeSelectedProcessDefinition,
@@ -12,6 +13,7 @@ import { loadManifest, renderServiceBlock, saveManifest } from "./manifest";
 import { normalizeProcessDefinition } from "./process-definition";
 import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager } from "./service-manager";
+import type { ExternalManagedProcess } from "./types";
 
 const launchPid = (pid: number): LaunchInstructionExecutionAdapter =>
   new LaunchInstructionExecutionAdapter({
@@ -45,6 +47,26 @@ class FailingReleaseClaims extends TestClaims {
     throw new Error("release failed");
   }
 }
+
+const externalProcess = (name = "db"): ExternalManagedProcess => ({
+  runtimeId: "docker",
+  runtimeName: "Docker Compose",
+  name,
+  state: "running",
+  status: "running",
+  ports: "",
+});
+
+const externalRuntime = (processes: ExternalManagedProcess[]): ExternalRuntime => ({
+  id: "docker",
+  name: "Docker Compose",
+  snapshot: async () => processes,
+  isAvailable: () => true,
+  stop: async () => {},
+  restart: async () => {},
+  streamOutput: () => null,
+  destroy: async () => {},
+});
 
 describe("Manifest Editing", () => {
   test("adds a Process Definition through one persisted runtime apply flow", async () => {
@@ -90,6 +112,40 @@ describe("Manifest Editing", () => {
       const manifest = await loadManifest(manifestPath);
       expect(manifest.services).toEqual([]);
       expect(manager.getConfigs()).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("accepts a Startup Dependency visible through External Runtime Visibility", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-edit-"));
+    const manifestPath = join(dir, "stasium.toml");
+    try {
+      await saveManifest(manifestPath, []);
+      const claims = new TestClaims(dir);
+      const externalRuntimeManager = new ExternalRuntimeVisibilityManager([
+        externalRuntime([externalProcess()]),
+      ]);
+      await externalRuntimeManager.refresh();
+      const manager = new ServiceManager([], {
+        processClaimStore: claims,
+        externalRuntimeManager,
+      });
+
+      await addProcessDefinition(
+        { manifestPath, manager, processClaimStore: claims, externalRuntimeManager },
+        {
+          name: "api",
+          launchInstruction: "bun run dev",
+          startupDependencies: ["docker:db"],
+        },
+      );
+
+      const manifest = await loadManifest(manifestPath, {
+        externalManagedProcessNames: ["docker:db"],
+      });
+      expect(manager.getConfigs()[0]?.startupDependencies).toEqual(["docker:db"]);
+      expect(manifest.services[0]?.startupDependencies).toEqual(["docker:db"]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/manifest-editing.ts
+++ b/src/manifest-editing.ts
@@ -1,10 +1,11 @@
 import { dirname } from "node:path";
 import { finalizeSelection, type DiscoverySelection } from "./discovery";
 import { DirectManagedProcessCollectionLifecycle } from "./direct-managed-process-collection";
+import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { parseServiceBlock, saveManifest } from "./manifest";
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
 import type { ProcessClaimStore } from "./process-claim";
-import { getTopologicalServiceOrder } from "./service-graph";
+import { getTopologicalServiceOrder, type ServiceGraphOptions } from "./service-graph";
 import type { ServiceManager } from "./service-manager";
 import { getErrorMessage } from "./shared";
 import type { AppConfig, ProcessDefinition } from "./types";
@@ -14,6 +15,7 @@ export interface ManifestEditingContext {
   appConfig?: AppConfig;
   manager: ServiceManager;
   processClaimStore: ProcessClaimStore;
+  externalRuntimeManager?: ExternalRuntimeVisibilityManager | null;
 }
 
 export interface ManifestEditingResult {
@@ -91,10 +93,13 @@ export const addSelectedDiscoveryCandidates = async (
   }
 
   const nextConfigs = [...context.manager.getConfigs(), ...finalized.services];
-  validateNextCollection(nextConfigs);
+  validateNextCollection(context, nextConfigs);
 
   const pendingByName = new Map(finalized.services.map((service) => [service.name, service]));
-  const orderedNames = getTopologicalServiceOrder(nextConfigs);
+  const orderedNames = getTopologicalServiceOrder(
+    nextConfigs,
+    dependencyValidationOptions(context),
+  );
 
   const result = await applyManifestEdit(context, {
     nextConfigs,
@@ -113,7 +118,7 @@ const applyManifestEdit = async (
   context: ManifestEditingContext,
   transaction: ManifestEditTransaction,
 ): Promise<ManifestEditingResult> => {
-  validateNextCollection(transaction.nextConfigs);
+  validateNextCollection(context, transaction.nextConfigs);
   await saveManifest(context.manifestPath, transaction.nextConfigs, context.appConfig);
   await transaction.apply();
 
@@ -132,6 +137,24 @@ const applyManifestEdit = async (
   return { services: context.manager.getConfigs(), warnings };
 };
 
-const validateNextCollection = (services: ProcessDefinition[]): void => {
-  new DirectManagedProcessCollectionLifecycle(() => services).validate(services);
+const validateNextCollection = (
+  context: ManifestEditingContext,
+  services: ProcessDefinition[],
+): void => {
+  new DirectManagedProcessCollectionLifecycle(
+    () => services,
+    dependencyValidationOptions(context),
+  ).validate(services);
+};
+
+const dependencyValidationOptions = (context: ManifestEditingContext): ServiceGraphOptions => {
+  const externalManagedProcessNames = context.externalRuntimeManager
+    ?.getProcesses()
+    .flatMap((process) => [process.name, `${process.runtimeId}:${process.name}`]);
+
+  return {
+    startupDependencyValidation: externalManagedProcessNames
+      ? { mode: "cross-runtime", externalManagedProcessNames }
+      : { mode: "direct-only" },
+  };
 };

--- a/src/startup-dependency-plan.ts
+++ b/src/startup-dependency-plan.ts
@@ -1,5 +1,6 @@
 import {
   ServiceGraphError,
+  type ServiceGraphOptions,
   getTopologicalServiceLayers,
   getTopologicalServiceOrder,
   validateServiceGraph,
@@ -21,7 +22,7 @@ export interface StartupDependencyPlan {
   blockedStatesFor: (unavailableNames: Iterable<string>) => BlockedProcessState[];
 }
 
-export interface StartupDependencyPlanOptions {
+export interface StartupDependencyPlanOptions extends ServiceGraphOptions {
   allowExternalDependencies?: boolean;
 }
 


### PR DESCRIPTION
Closes #71

## Summary
- Threads External Runtime Visibility into Manifest Editing operations.
- Reuses the shared Startup Dependency validation mode for edit validation and discovery ordering.
- Preserves direct-only rejection when no external runtime visibility is available.

## Verification
- `bun test src/manifest-editing.test.ts src/service-graph.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.