### PR TITLE
Cover startup external dependency ownership

### DIFF
--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -124,7 +124,7 @@ describe("ServiceManager", () => {
     await manager.stopAll();
   });
 
-  test("starts unavailable External Managed Process dependencies before direct processes", async () => {
+  test("starts unavailable External Managed Process dependencies without claiming ownership", async () => {
     const actions: string[] = [];
     const claims: string[] = [];
     class TestClaims extends ProcessClaimStore {
@@ -145,7 +145,7 @@ describe("ServiceManager", () => {
         service({
           name: "api",
           launchInstruction: ["bun", "run", "dev"],
-          startupDependencies: ["db"],
+          startupDependencies: ["docker-compose:db"],
         }),
       ],
       {


### PR DESCRIPTION
Closes #72

## Summary
- Adds regression coverage for resolving a runtime-qualified External Managed Process Startup Dependency during direct process startup.
- Verifies the External Managed Process is started through External Runtime Visibility while Process Claims remain limited to the Direct Managed Process.
- Leaves runtime behavior unchanged because the existing startup path already satisfies the acceptance criteria.

## Verification
- `bun test src/service-manager.test.ts src/external-runtime.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.