### PR TITLE
Route startup ordering through direct collection

### DIFF
--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -136,7 +136,7 @@ export class ServiceManager {
   }
 
   async startAll(options: { shouldCancel?: () => boolean } = {}): Promise<void> {
-    const layers = this.getTopologicalLayers();
+    const layers = this.getStartupLayers();
 
     for (const layer of layers) {
       if (options.shouldCancel?.()) return;
@@ -398,15 +398,11 @@ export class ServiceManager {
     });
   }
 
-  private getTopologicalOrderNames(): string[] {
-    return this.runGraphOperation(() => this.collectionLifecycle.startupOrder());
-  }
-
   private getShutdownOrderNames(): string[] {
     return this.runGraphOperation(() => this.collectionLifecycle.shutdownOrder());
   }
 
-  private getTopologicalLayers(): string[][] {
+  private getStartupLayers(): string[][] {
     return this.runGraphOperation(() => this.collectionLifecycle.startupLayers());
   }
 


### PR DESCRIPTION
Closes #82

## Summary
- Renames the ServiceManager startup layer accessor to collection-owned Startup vocabulary.
- Removes an unused graph-vocabulary startup-order helper.
- Keeps startup and reverse shutdown behavior unchanged through the existing Direct Managed Process collection interface.

## Verification
- `bun test src/direct-managed-process-collection.test.ts src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.