### PR TITLE
Collect restart lifecycle coordination

### DIFF
--- a/src/direct-managed-process-lifecycle.test.ts
+++ b/src/direct-managed-process-lifecycle.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DirectManagedProcessLifecycle,
+  DirectManagedProcessLifecycleCollection,
+  type RestartRuleLifecycleView,
+} from "./direct-managed-process-lifecycle";
+import { normalizeProcessDefinition } from "./process-definition";
+
+describe("Direct Managed Process lifecycle collection", () => {
+  test("coordinates pending Restart Rule ticks without renderer setup", () => {
+    const view: RestartRuleLifecycleView = {
+      config: normalizeProcessDefinition({
+        name: "api",
+        launchInstruction: "bun run dev",
+        restartRule: "on-failure",
+      }),
+      restartCount: 0,
+      restartInMs: null,
+    };
+    const lifecycle = new DirectManagedProcessLifecycle({
+      onChange: () => {},
+      onRestart: async () => {},
+      isActive: () => true,
+      isRunning: () => false,
+    });
+    const collection = new DirectManagedProcessLifecycleCollection<string>();
+
+    collection.set("api", lifecycle);
+    lifecycle.noteExit(view, 1);
+
+    expect(collection.hasPendingRestart()).toBe(true);
+    expect(collection.tick(() => view, Date.now() + 1000)).toBe(true);
+    expect(view.restartInMs).toBe(0);
+
+    lifecycle.suppressRestart(view);
+  });
+});

--- a/src/direct-managed-process-lifecycle.ts
+++ b/src/direct-managed-process-lifecycle.ts
@@ -135,3 +135,33 @@ export class DirectManagedProcessLifecycle {
     this.runStableTimer = null;
   }
 }
+
+export class DirectManagedProcessLifecycleCollection<TProcess> {
+  private readonly lifecycles = new Map<TProcess, DirectManagedProcessLifecycle>();
+
+  set(process: TProcess, lifecycle: DirectManagedProcessLifecycle): void {
+    this.lifecycles.set(process, lifecycle);
+  }
+
+  get(process: TProcess): DirectManagedProcessLifecycle | null {
+    return this.lifecycles.get(process) ?? null;
+  }
+
+  delete(process: TProcess): void {
+    this.lifecycles.delete(process);
+  }
+
+  hasPendingRestart(): boolean {
+    return [...this.lifecycles.values()].some((lifecycle) => lifecycle.hasPendingRestart());
+  }
+
+  tick(getView: (process: TProcess) => RestartRuleLifecycleView | null, now: number): boolean {
+    let changed = false;
+    for (const [process, lifecycle] of this.lifecycles.entries()) {
+      const view = getView(process);
+      if (!view) continue;
+      changed = lifecycle.tick(view, now) || changed;
+    }
+    return changed;
+  }
+}

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -1,5 +1,8 @@
 import { DirectManagedProcessCollectionLifecycle } from "./direct-managed-process-collection";
-import { DirectManagedProcessLifecycle } from "./direct-managed-process-lifecycle";
+import {
+  DirectManagedProcessLifecycle,
+  DirectManagedProcessLifecycleCollection,
+} from "./direct-managed-process-lifecycle";
 import { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { LogBuffer } from "./log-buffer";
 import { LaunchInstructionExecutionAdapter } from "./launch-execution";
@@ -42,7 +45,7 @@ export class ServiceManager {
   private services: ServiceProcess[];
   private views: ServiceView[];
   private unsubscribers: Array<() => void>;
-  private readonly lifecycles: Map<ServiceProcess, DirectManagedProcessLifecycle> = new Map();
+  private readonly lifecycles = new DirectManagedProcessLifecycleCollection<ServiceProcess>();
   private readonly collectionLifecycle: DirectManagedProcessCollectionLifecycle;
   private readonly launchAdapter: LaunchInstructionExecutionAdapter;
   private readonly processClaimStore: ProcessClaimStore | null;
@@ -486,16 +489,10 @@ export class ServiceManager {
     if (this.restartTicker) return;
 
     this.restartTicker = setInterval(() => {
-      let changed = false;
       const now = Date.now();
+      const changed = this.lifecycles.tick((service) => this.getViewByService(service), now);
 
-      for (const [service, lifecycle] of this.lifecycles.entries()) {
-        const view = this.getViewByService(service);
-        if (!view) continue;
-        changed = lifecycle.tick(view, now) || changed;
-      }
-
-      if (![...this.lifecycles.values()].some((lifecycle) => lifecycle.hasPendingRestart())) {
+      if (!this.lifecycles.hasPendingRestart()) {
         this.stopRestartTicker();
       }
 


### PR DESCRIPTION
Closes #83

## Summary
- Adds a Direct Managed Process lifecycle collection wrapper for restart tick and pending-restart coordination.
- Routes ServiceManager restart ticker coordination through that collection instead of a raw lifecycle map.
- Adds renderer-free lifecycle collection coverage while preserving existing Restart Rule semantics.

## Verification
- `bun test src/direct-managed-process-lifecycle.test.ts src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.