### PR TITLE
Isolate Workspace selection from direct collection

### DIFF
--- a/src/direct-managed-process-collection.test.ts
+++ b/src/direct-managed-process-collection.test.ts
@@ -58,4 +58,14 @@ describe("Direct Managed Process collection", () => {
       ]),
     ).toThrow();
   });
+
+  test("does not expose Workspace selection semantics", () => {
+    const collection: DirectManagedProcessCollection = new DirectManagedProcessCollectionLifecycle(
+      processDefinitions,
+    );
+
+    expect("getSelectedIndex" in collection).toBe(false);
+    expect("setSelectedIndex" in collection).toBe(false);
+    expect("moveSelection" in collection).toBe(false);
+  });
 });

--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -101,6 +101,18 @@ describe("ServiceManager", () => {
     );
   });
 
+  test("keeps Workspace row selection outside Direct Managed Process collection mutations", async () => {
+    const manager = new ServiceManager([makeConfig("api"), makeConfig("worker")], {
+      launchAdapter: launchLongRunningPid(13),
+    });
+    manager.setSelectedIndex(1);
+
+    await manager.updateProcessDefinition(0, makeConfig("web"));
+
+    expect(manager.getSelectedIndex()).toBe(1);
+    expect(manager.getSelectedConfig()?.name).toBe("worker");
+  });
+
   test("starts dependencies before selected service", async () => {
     const manager = new ServiceManager([
       service({


### PR DESCRIPTION
Closes #84

## Summary
- Adds public-seam coverage proving Direct Managed Process collection does not expose Workspace row selection semantics.
- Adds ServiceManager coverage proving Workspace selection stays stable across direct collection-backed mutations.
- Leaves runtime behavior unchanged.

## Verification
- `bun test src/direct-managed-process-collection.test.ts src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.