### PR TITLE
Preserve process state and output visibility

### DIFF
--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -136,6 +136,28 @@ describe("ServiceManager", () => {
     await manager.stopAll();
   });
 
+  test("keeps Process State and Process Output visible through the public runtime interface", async () => {
+    const manager = new ServiceManager([
+      service({
+        name: "api",
+        launchInstruction: ["bun", "-e", 'console.log("api-ready"); setInterval(() => {}, 1000);'],
+      }),
+    ]);
+
+    await manager.startAll();
+
+    const visible = await waitFor(() => {
+      const view = manager.getViews()[0];
+      return (
+        view?.state === "RUNNING" &&
+        view.log.all().some((entry) => entry.stream === "stdout" && entry.line === "api-ready")
+      );
+    });
+    expect(visible).toBe(true);
+
+    await manager.stopAll();
+  });
+
   test("starts unavailable External Managed Process dependencies without claiming ownership", async () => {
     const actions: string[] = [];
     const claims: string[] = [];


### PR DESCRIPTION
Closes #86

## Summary
- Adds regression coverage proving Process State remains visible through the public runtime interface.
- Adds regression coverage proving Process Output remains visible through the public runtime interface.
- Leaves runtime behavior unchanged.

## Verification
- `bun test src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.