### PR TITLE
Derive startup blocked states from plan

### DIFF
--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -398,6 +398,50 @@ describe("ServiceManager", () => {
     expect(launched).toEqual(["missing"]);
   });
 
+  test("derives cascading blocked state from the Startup Dependency plan", async () => {
+    const launched: string[] = [];
+    const launchAdapter = new LaunchInstructionExecutionAdapter({
+      now: () => "now",
+      pathReader: async () => process.env.PATH ?? "",
+      spawner: (options) => {
+        launched.push(options.cmd[0] ?? "");
+        if (options.cmd[0] === "missing") throw new Error("missing executable");
+        return {
+          pid: 1,
+          stdout: null,
+          stderr: null,
+          exited: new Promise(() => {}),
+          signalCode: null,
+          kill: () => {},
+        };
+      },
+    });
+    const manager = new ServiceManager(
+      [
+        service({ name: "db", launchInstruction: ["missing"] }),
+        service({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["db"],
+        }),
+        service({
+          name: "worker",
+          launchInstruction: ["bun", "run", "worker"],
+          startupDependencies: ["api"],
+        }),
+      ],
+      { launchAdapter },
+    );
+
+    await manager.startAll();
+
+    expect(manager.getViews().map((view) => view.state)).toEqual(["FAILED", "BLOCKED", "BLOCKED"]);
+    expect(manager.getViews()[2]?.log.all().at(-1)?.line).toBe(
+      'Startup blocked by failed Startup Dependency "api".',
+    );
+    expect(launched).toEqual(["missing"]);
+  });
+
   test("tracks manual restarts separately from automatic Restart Rule attempts", async () => {
     const manager = new ServiceManager([
       service({

--- a/src/service-manager.ts
+++ b/src/service-manager.ts
@@ -9,7 +9,7 @@ import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { ProcessClaimStore } from "./process-claim";
 import { type ServiceEvent, ServiceProcess } from "./service";
 import { ServiceGraphError } from "./service-graph";
-import { StartupDependencyPlanError } from "./startup-dependency-plan";
+import { StartupDependencyPlanError, planStartupDependencies } from "./startup-dependency-plan";
 import type { ProcessDefinition, ServicePid, ServiceState } from "./types";
 
 export interface ServiceView {
@@ -451,14 +451,28 @@ export class ServiceManager {
 
   private async startServiceUnlessBlocked(service: ServiceProcess): Promise<void> {
     const blockedBy = await this.getUnavailableDependencies(service.config);
-    if (blockedBy.length > 0) {
+    const blockedState = this.getPlannedBlockedState(service.config.name, blockedBy);
+    if (blockedState) {
       service.block(
-        `Startup blocked by failed Startup Dependency ${blockedBy.map((name) => `"${name}"`).join(", ")}.`,
+        `Startup blocked by failed Startup Dependency ${blockedState.blockedBy
+          .map((name) => `"${name}"`)
+          .join(", ")}.`,
       );
       return;
     }
 
     await this.startService(service);
+  }
+
+  private getPlannedBlockedState(name: string, blockedBy: string[]) {
+    if (blockedBy.length === 0) return null;
+    return this.runGraphOperation(() =>
+      planStartupDependencies(this.getConfigs(), {
+        allowExternalDependencies: this.externalRuntimeManager !== null,
+      })
+        .blockedStatesFor(blockedBy)
+        .find((state) => state.name === name),
+    );
   }
 
   private async getUnavailableDependencies(config: ProcessDefinition): Promise<string[]> {


### PR DESCRIPTION
Closes #89

## Summary
- Routes runtime blocked Process State derivation through the Startup Dependency plan interface.
- Preserves existing runtime blocked-state log text and downstream start prevention behavior.
- Adds a cascading blocked-state startup regression matching the planning model.

## Verification
- `bun test src/startup-dependency-plan.test.ts src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.