### PR TITLE
Cover cross-runtime blocked-state planning

### DIFF
--- a/src/cross-runtime-startup-dependencies.test.ts
+++ b/src/cross-runtime-startup-dependencies.test.ts
@@ -126,6 +126,7 @@ describe("cross-runtime Startup Dependencies", () => {
 
   test("blocks Startup when a visible External Managed Process stays unavailable", async () => {
     const actions: string[] = [];
+    const claims = new TestClaims(process.cwd());
     const externalRuntimeManager = new ExternalRuntimeVisibilityManager([
       externalRuntime(() => [externalProcess("db", "exited")], actions),
     ]);
@@ -137,7 +138,7 @@ describe("cross-runtime Startup Dependencies", () => {
           startupDependencies: ["docker-compose:db"],
         }),
       ],
-      { externalRuntimeManager, launchAdapter: launchPid(40) },
+      { externalRuntimeManager, launchAdapter: launchPid(40), processClaimStore: claims },
     );
 
     await manager.startAll();
@@ -145,6 +146,10 @@ describe("cross-runtime Startup Dependencies", () => {
     expect(actions).toEqual(["start:db"]);
     expect(manager.getSelectedView()?.state).toBe("BLOCKED");
     expect(manager.getServicePids()).toEqual([]);
+    expect(claims.claims).toEqual([]);
+    expect(manager.getSelectedView()?.log.all().at(-1)?.line).toBe(
+      'Startup blocked by failed Startup Dependency "docker-compose:db".',
+    );
   });
 
   test("claims only Direct Managed Processes when Startup starts an external dependency", async () => {

--- a/src/startup-dependency-plan.test.ts
+++ b/src/startup-dependency-plan.test.ts
@@ -107,4 +107,37 @@ describe("Startup Dependency planning", () => {
     ]);
     expect(plan.blockedStatesFor(["db"])).toEqual(getBlockedProcessStates(plan, ["db"]));
   });
+
+  test("represents external availability blockers in the same blocked-state model", () => {
+    const plan = planStartupDependencies(
+      [
+        processDefinition({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["docker-compose:db"],
+        }),
+        processDefinition({
+          name: "worker",
+          launchInstruction: ["bun", "run", "worker"],
+          startupDependencies: ["api"],
+        }),
+      ],
+      { allowExternalDependencies: true },
+    );
+
+    expect(plan.blockedStatesFor(["docker-compose:db"])).toEqual([
+      {
+        name: "api",
+        state: "BLOCKED",
+        blockedBy: ["docker-compose:db"],
+        reason: 'Startup Dependency "docker-compose:db" failed to become available.',
+      },
+      {
+        name: "worker",
+        state: "BLOCKED",
+        blockedBy: ["api"],
+        reason: 'Startup Dependency "api" failed to become available.',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Closes #90

## Summary
- Adds Startup Dependency planning coverage for external availability blockers.
- Extends cross-runtime startup regression coverage to assert unavailable external dependencies use the same blocked-state message path.
- Verifies external blockers do not create Process Claims.

## Verification
- `bun test src/startup-dependency-plan.test.ts src/cross-runtime-startup-dependencies.test.ts src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.