### PR TITLE
Cover blocked state recomputation

### DIFF
--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -220,6 +220,35 @@ describe("ServiceManager", () => {
     expect(manager.getServicePids()).toHaveLength(0);
   });
 
+  test("recomputes blocked state when an External Managed Process dependency becomes available", async () => {
+    const actions: string[] = [];
+    let dbState: ExternalManagedProcess["state"] = "exited";
+    const externalRuntimeManager = new ExternalRuntimeVisibilityManager([
+      externalRuntime(() => [externalProcess("db", dbState)], actions),
+    ]);
+    const manager = new ServiceManager(
+      [
+        service({
+          name: "api",
+          launchInstruction: ["bun", "run", "dev"],
+          startupDependencies: ["docker-compose:db"],
+        }),
+      ],
+      { externalRuntimeManager, launchAdapter: launchLongRunningPid(22) },
+    );
+
+    await manager.startAll();
+    expect(manager.getSelectedView()?.state).toBe("BLOCKED");
+    expect(manager.getServicePids()).toHaveLength(0);
+
+    dbState = "running";
+    await manager.startAll();
+
+    expect(actions).toEqual(["start:db"]);
+    expect(manager.getSelectedView()?.state).toBe("RUNNING");
+    expect(manager.getServicePids().map((entry) => entry.name)).toEqual(["api"]);
+  });
+
   test("stops selected dependency and its dependents", async () => {
     const manager = new ServiceManager([
       service({


### PR DESCRIPTION
Closes #91

## Summary
- Adds regression coverage for recomputing blocked Process State on a subsequent startup attempt.
- Verifies an External Managed Process dependency becoming available lets a previously blocked Direct Managed Process start.
- Leaves runtime behavior unchanged.

## Verification
- `bun test src/service-manager.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.