### PR TITLE
Add blocked Process State regressions

### DIFF
--- a/src/service-manager.test.ts
+++ b/src/service-manager.test.ts
@@ -4,6 +4,7 @@ import { LaunchInstructionExecutionAdapter } from "./launch-execution";
 import { normalizeProcessDefinition, type ProcessDefinitionInput } from "./process-definition";
 import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager, ServiceManagerError } from "./service-manager";
+import { planStartupDependencies } from "./startup-dependency-plan";
 import type { ExternalManagedProcess, LogEntry, ProcessDefinition, ServicePid } from "./types";
 
 const service = (input: ProcessDefinitionInput): ProcessDefinition =>
@@ -417,10 +418,18 @@ describe("ServiceManager", () => {
       ],
       { launchAdapter },
     );
+    const expectedPlanState = planStartupDependencies(manager.getConfigs()).blockedStatesFor([
+      "db",
+    ])[0];
 
     await manager.startAll();
 
     expect(manager.getViews()[1]?.state).toBe("BLOCKED");
+    expect(expectedPlanState).toMatchObject({
+      name: "api",
+      state: "BLOCKED",
+      blockedBy: ["db"],
+    });
     expect(manager.getViews()[1]?.log.all().at(-1)?.line).toBe(
       'Startup blocked by failed Startup Dependency "db".',
     );


### PR DESCRIPTION
Closes #92

## Summary
- Adds an explicit plan/runtime equivalence assertion for direct failure blocked states.
- Complements existing plan coverage for direct and external blockers plus runtime cross-runtime blocker coverage.
- Leaves dependency syntax and runtime behavior unchanged.

## Verification
- `bun test src/startup-dependency-plan.test.ts src/service-manager.test.ts src/cross-runtime-startup-dependencies.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.