### PR TITLE
Cover External Runtime output streaming

### DIFF
--- a/src/external-runtime.test.ts
+++ b/src/external-runtime.test.ts
@@ -114,6 +114,42 @@ describe("ExternalRuntimeVisibilityManager", () => {
     expect(actions).toEqual(["podman:restart:cache"]);
   });
 
+  test("streams selected External Process Output through the active log buffer", async () => {
+    let emit = (_entry: LogEntry): void => {};
+    const testRuntime = runtime("docker", [process("docker", "db")]);
+    testRuntime.streamOutput = (name, onOutput) => {
+      emit = onOutput;
+      return { stop: () => {} };
+    };
+    const manager = new ExternalRuntimeVisibilityManager([testRuntime]);
+
+    await manager.refresh();
+    manager.streamSelectedLogs();
+    emit({ timestamp: "2026-06-01T12:00:00Z", line: "ready", stream: "stdout" });
+
+    expect(manager.getActiveLogBuffer()?.all()).toEqual([
+      { timestamp: "2026-06-01T12:00:00Z", line: "ready", stream: "stdout" },
+    ]);
+    expect(manager.getSelectedLogBuffer()?.all()).toEqual([
+      { timestamp: "2026-06-01T12:00:00Z", line: "ready", stream: "stdout" },
+    ]);
+  });
+
+  test("stops previous External Process Output stream when selection changes", async () => {
+    const actions: string[] = [];
+    const testRuntime = runtime("docker", [process("docker", "db"), process("docker", "cache")]);
+    testRuntime.streamOutput = (name) => {
+      actions.push(`stream:${name}`);
+      return { stop: () => actions.push(`stop:${name}`) };
+    };
+    const manager = new ExternalRuntimeVisibilityManager([testRuntime]);
+
+    await manager.refresh();
+    manager.selectIndex(1);
+
+    expect(actions).toEqual(["stream:db", "stop:db", "stream:cache"]);
+  });
+
   test("tracks and stops External Managed Processes auto-started for Startup Dependencies", async () => {
     const actions: string[] = [];
     let state: ExternalManagedProcess["state"] = "exited";


### PR DESCRIPTION
Closes #98

## Summary
- Adds public-seam coverage for External Process Output streaming through External Runtime Visibility.
- Verifies streamed output reaches the active and selected log buffers.
- Verifies changing selection stops the previous output stream and starts the new one.

## Verification
- `bun test src/external-runtime.test.ts src/workspace-startup.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.