### PR TITLE
Cover External Runtime Session regressions

### DIFF
--- a/src/cross-runtime-startup-dependencies.test.ts
+++ b/src/cross-runtime-startup-dependencies.test.ts
@@ -152,7 +152,7 @@ describe("cross-runtime Startup Dependencies", () => {
     );
   });
 
-  test("claims only Direct Managed Processes when Startup starts an external dependency", async () => {
+  test("claims only Direct Managed Processes and cleans up external session starts", async () => {
     const actions: string[] = [];
     let dbState: ExternalManagedProcess["state"] = "exited";
     const runtime = externalRuntime(() => [externalProcess("db", dbState)], actions);
@@ -174,8 +174,9 @@ describe("cross-runtime Startup Dependencies", () => {
     );
 
     await manager.startAll();
+    await externalRuntimeManager.stopSessionStartedProcesses();
 
-    expect(actions).toEqual(["start:db"]);
+    expect(actions).toEqual(["start:db", "stop:db"]);
     expect(claims.claims).toEqual(["api"]);
     expect(manager.getSelectedView()?.state).toBe("RUNNING");
   });


### PR DESCRIPTION
Closes #99

## Summary
- Extends cross-runtime Startup Dependency coverage to exercise External Runtime Session cleanup.
- Verifies auto-started external dependencies receive cleanup stop requests.
- Verifies external session tracking still does not create Process Claims; only Direct Managed Processes are claimed.

## Verification
- `bun test src/cross-runtime-startup-dependencies.test.ts src/external-runtime.test.ts src/shutdown.test.ts` passed
- `bun run typecheck` passed
- `bun run lint` passed
- `bun run format:check` passed
- `bun run test` passed
- `bun run build` passed

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.