### PR TITLE
feat: introduce cli command runner

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
 import { STASIUM_VERSION } from "./version";
 import { startWorkspace, type ShutdownController } from "./workspace-startup";
+import { runCommand } from "./cli";
 
 const MANIFEST_PATH = "stasium.toml";
 
@@ -795,8 +796,7 @@ const startInitFlow = (
   })();
 };
 
-export const run = async () => {
-  const args = process.argv.slice(2);
+const runInteractiveApp = async (args: string[]): Promise<void> => {
   const hasManifest = await fileExists(MANIFEST_PATH);
   const teardownRef: { current: (() => void) | null } = { current: null };
   const shutdownRef: { current: ShutdownController | null } = { current: null };
@@ -936,4 +936,17 @@ export const run = async () => {
   });
 
   renderer.start();
+};
+
+export const run = async () => {
+  const result = await runCommand({
+    argv: process.argv.slice(2),
+    legacyRootCommands: ["init"],
+    root: async (args) => {
+      await runInteractiveApp(args);
+      return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+    },
+  });
+
+  process.exitCode = result.exitCode;
 };

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { runCommand, type CommandContext, type CommandResult } from "./cli";
+
+const noopContextHandler = async (): Promise<CommandResult> => ({ exitCode: 0 });
+
+describe("Command Runner", () => {
+  test("delegates the root command when no argv is provided", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: [],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 0 };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([[]]);
+  });
+
+  test("dispatches registered non-root commands with injected output", async () => {
+    const stdout: string[] = [];
+    const contexts: CommandContext[] = [];
+
+    const result = await runCommand({
+      argv: ["example", "--flag"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        example: async (args, context) => {
+          contexts.push(context);
+          context.stdout(args.join(" "));
+          return { exitCode: 7 };
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 7 });
+    expect(stdout).toEqual(["--flag"]);
+    expect(contexts).toHaveLength(1);
+  });
+
+  test("passes legacy root commands to the root handler", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: ["init"],
+      legacyRootCommands: ["init"],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 0 };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([["init"]]);
+  });
+
+  test("returns a command failure for unknown commands", async () => {
+    const stderr: string[] = [];
+
+    const result = await runCommand({
+      argv: ["wat"],
+      stderr: (message) => stderr.push(message),
+      root: noopContextHandler,
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(stderr).toEqual(["Unknown command: wat"]);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,37 @@
+export interface CommandContext {
+  stdout: (message: string) => void;
+  stderr: (message: string) => void;
+}
+
+export interface CommandResult {
+  exitCode: number;
+}
+
+export type CommandHandler = (args: string[], context: CommandContext) => Promise<CommandResult>;
+
+export interface RunCommandOptions {
+  argv: string[];
+  stdout?: (message: string) => void;
+  stderr?: (message: string) => void;
+  root: CommandHandler;
+  commands?: Record<string, CommandHandler>;
+  legacyRootCommands?: string[];
+}
+
+export const runCommand = async (options: RunCommandOptions): Promise<CommandResult> => {
+  const [name, ...rest] = options.argv;
+  const context: CommandContext = {
+    stdout: options.stdout ?? console.log,
+    stderr: options.stderr ?? console.error,
+  };
+
+  if (!name) return options.root([], context);
+
+  const command = options.commands?.[name];
+  if (command) return command(rest, context);
+
+  if (options.legacyRootCommands?.includes(name)) return options.root(options.argv, context);
+
+  context.stderr(`Unknown command: ${name}`);
+  return { exitCode: 1 };
+};


### PR DESCRIPTION
Closes #129

## Summary

- Added an injectable CLI command runner seam for root and named command dispatch.
- Wrapped the existing interactive Workspace/Project Setup runner through the command runner while preserving default `stasium` behavior.
- Kept `stasium init` as a legacy root-dispatched command for this slice so the next issue can move it into the command tree explicitly.
- Added command-runner tests for root dispatch, injected IO, legacy passthrough, and unknown-command failures.

## Verification

- `bun test src/cli.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`

## Self Review

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
