### PR TITLE
feat: add explicit update command

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -941,14 +941,27 @@ const runInteractiveApp = async (args: string[]): Promise<void> => {
 export const run = async () => {
   const result = await runCommand({
     argv: process.argv.slice(2),
+    version: STASIUM_VERSION,
     root: async (args) => {
       await runInteractiveApp(args);
       return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
     },
     commands: {
-      init: async (args) => {
-        await runInteractiveApp(["init", ...args]);
-        return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+      init: {
+        usage: "stasium init",
+        description: "Start explicit Project Setup for this Project.",
+        handler: async (args) => {
+          await runInteractiveApp(["init", ...args]);
+          return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+        },
+      },
+      version: {
+        usage: "stasium version",
+        description: "Print the installed Stasium version.",
+        handler: async (_args, context) => {
+          context.stdout(STASIUM_VERSION);
+          return { exitCode: 0 };
+        },
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
 import { STASIUM_VERSION } from "./version";
 import { startWorkspace, type ShutdownController } from "./workspace-startup";
+import { runCommand } from "./cli";
 
 const MANIFEST_PATH = "stasium.toml";
 
@@ -795,8 +796,7 @@ const startInitFlow = (
   })();
 };
 
-export const run = async () => {
-  const args = process.argv.slice(2);
+const runInteractiveApp = async (args: string[]): Promise<void> => {
   const hasManifest = await fileExists(MANIFEST_PATH);
   const teardownRef: { current: (() => void) | null } = { current: null };
   const shutdownRef: { current: ShutdownController | null } = { current: null };
@@ -936,4 +936,17 @@ export const run = async () => {
   });
 
   renderer.start();
+};
+
+export const run = async () => {
+  const result = await runCommand({
+    argv: process.argv.slice(2),
+    legacyRootCommands: ["init"],
+    root: async (args) => {
+      await runInteractiveApp(args);
+      return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+    },
+  });
+
+  process.exitCode = result.exitCode;
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { fileExists, getErrorMessage } from "./shared";
 import { currentUpdatePlatform, runStartupUpdateCheck } from "./startup-update";
 import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
+import { runUpdateCommand } from "./update-command";
 import { STASIUM_VERSION } from "./version";
 import { startWorkspace, type ShutdownController } from "./workspace-startup";
 import { runCommand } from "./cli";
@@ -962,6 +963,15 @@ export const run = async () => {
           context.stdout(STASIUM_VERSION);
           return { exitCode: 0 };
         },
+      },
+      update: {
+        usage: "stasium update [--check] [--channel <channel>]",
+        description: "Check for and install a Stasium update.",
+        handler: (args, context) =>
+          runUpdateCommand(args, context, {
+            currentVersion: STASIUM_VERSION,
+            executablePath: process.argv[0] ?? process.execPath,
+          }),
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -941,10 +941,15 @@ const runInteractiveApp = async (args: string[]): Promise<void> => {
 export const run = async () => {
   const result = await runCommand({
     argv: process.argv.slice(2),
-    legacyRootCommands: ["init"],
     root: async (args) => {
       await runInteractiveApp(args);
       return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+    },
+    commands: {
+      init: async (args) => {
+        await runInteractiveApp(["init", ...args]);
+        return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+      },
     },
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { runCommand, type CommandContext, type CommandResult } from "./cli";
+
+const noopContextHandler = async (): Promise<CommandResult> => ({ exitCode: 0 });
+
+describe("Command Runner", () => {
+  test("delegates the root command when no argv is provided", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: [],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 0 };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([[]]);
+  });
+
+  test("dispatches registered non-root commands with injected output", async () => {
+    const stdout: string[] = [];
+    const contexts: CommandContext[] = [];
+
+    const result = await runCommand({
+      argv: ["example", "--flag"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        example: async (args, context) => {
+          contexts.push(context);
+          context.stdout(args.join(" "));
+          return { exitCode: 7 };
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 7 });
+    expect(stdout).toEqual(["--flag"]);
+    expect(contexts).toHaveLength(1);
+  });
+
+  test("passes legacy root commands to the root handler", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: ["init"],
+      legacyRootCommands: ["init"],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 0 };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([["init"]]);
+  });
+
+  test("returns a command failure for unknown commands", async () => {
+    const stderr: string[] = [];
+
+    const result = await runCommand({
+      argv: ["wat"],
+      stderr: (message) => stderr.push(message),
+      root: noopContextHandler,
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(stderr).toEqual(["Unknown command: wat"]);
+  });
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -88,6 +88,82 @@ describe("Command Runner", () => {
     });
 
     expect(result).toEqual({ exitCode: 1 });
-    expect(stderr).toEqual(["Unknown command: wat"]);
+    expect(stderr).toEqual(['Unknown command: wat. Run "stasium --help" for usage.']);
+  });
+
+  test("prints root help without running the root handler", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["--help"],
+      stdout: (message) => stdout.push(message),
+      root: async () => ({ exitCode: 1 }),
+      commands: {
+        init: {
+          usage: "stasium init",
+          description: "Start Project Setup.",
+          handler: noopContextHandler,
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout[0]).toContain("Usage: stasium [command]");
+    expect(stdout[0]).toContain("Run Stasium's interactive Workspace");
+    expect(stdout[0]).toContain("init  Start Project Setup.");
+  });
+
+  test("prints command help", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["help", "init"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        init: {
+          usage: "stasium init",
+          description: "Start Project Setup.",
+          handler: noopContextHandler,
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout).toEqual(["stasium init\n\nStart Project Setup."]);
+  });
+
+  test("prints command help from command flags", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["init", "--help"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        init: {
+          usage: "stasium init",
+          description: "Start Project Setup.",
+          handler: noopContextHandler,
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout).toEqual(["stasium init\n\nStart Project Setup."]);
+  });
+
+  test("prints version output", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["--version"],
+      version: "1.2.3",
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout).toEqual(["1.2.3"]);
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -41,12 +41,33 @@ describe("Command Runner", () => {
     expect(contexts).toHaveLength(1);
   });
 
-  test("passes legacy root commands to the root handler", async () => {
+  test("dispatches registered commands instead of the root handler", async () => {
     const calls: string[][] = [];
 
     const result = await runCommand({
       argv: ["init"],
-      legacyRootCommands: ["init"],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 1 };
+      },
+      commands: {
+        init: async (args) => {
+          calls.push(["init", ...args]);
+          return { exitCode: 0 };
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([["init"]]);
+  });
+
+  test("can temporarily pass legacy root commands to the root handler", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: ["legacy"],
+      legacyRootCommands: ["legacy"],
       root: async (args) => {
         calls.push(args);
         return { exitCode: 0 };
@@ -54,7 +75,7 @@ describe("Command Runner", () => {
     });
 
     expect(result).toEqual({ exitCode: 0 });
-    expect(calls).toEqual([["init"]]);
+    expect(calls).toEqual([["legacy"]]);
   });
 
   test("returns a command failure for unknown commands", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,14 +9,56 @@ export interface CommandResult {
 
 export type CommandHandler = (args: string[], context: CommandContext) => Promise<CommandResult>;
 
+export interface CommandDefinition {
+  description: string;
+  usage: string;
+  handler: CommandHandler;
+}
+
 export interface RunCommandOptions {
   argv: string[];
   stdout?: (message: string) => void;
   stderr?: (message: string) => void;
   root: CommandHandler;
-  commands?: Record<string, CommandHandler>;
+  rootUsage?: string;
+  rootDescription?: string;
+  version?: string;
+  commands?: Record<string, CommandHandler | CommandDefinition>;
   legacyRootCommands?: string[];
 }
+
+const normalizeCommand = (
+  name: string,
+  command: CommandHandler | CommandDefinition,
+): CommandDefinition => {
+  if (typeof command === "function") {
+    return { usage: `stasium ${name}`, description: "", handler: command };
+  }
+  return command;
+};
+
+const buildRootHelp = (options: RunCommandOptions): string => {
+  const lines = [
+    options.rootUsage ?? "Usage: stasium [command]",
+    "",
+    options.rootDescription ??
+      "Run Stasium's interactive Workspace, or start Project Setup when no Manifest exists.",
+  ];
+
+  const entries = Object.entries(options.commands ?? {});
+  if (entries.length > 0) {
+    lines.push("", "Commands:");
+    for (const [name, command] of entries) {
+      const definition = normalizeCommand(name, command);
+      lines.push(`  ${name}${definition.description ? `  ${definition.description}` : ""}`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+const buildCommandHelp = (name: string, command: CommandDefinition): string =>
+  command.description ? `${command.usage}\n\n${command.description}` : command.usage;
 
 export const runCommand = async (options: RunCommandOptions): Promise<CommandResult> => {
   const [name, ...rest] = options.argv;
@@ -27,11 +69,45 @@ export const runCommand = async (options: RunCommandOptions): Promise<CommandRes
 
   if (!name) return options.root([], context);
 
+  if (name === "--help" || name === "-h") {
+    context.stdout(buildRootHelp(options));
+    return { exitCode: 0 };
+  }
+
+  if ((name === "--version" || name === "-v") && options.version) {
+    context.stdout(options.version);
+    return { exitCode: 0 };
+  }
+
+  if (name === "help") {
+    const [target] = rest;
+    if (!target) {
+      context.stdout(buildRootHelp(options));
+      return { exitCode: 0 };
+    }
+
+    const command = options.commands?.[target];
+    if (!command) {
+      context.stderr(`Unknown command: ${target}`);
+      return { exitCode: 1 };
+    }
+
+    context.stdout(buildCommandHelp(target, normalizeCommand(target, command)));
+    return { exitCode: 0 };
+  }
+
   const command = options.commands?.[name];
-  if (command) return command(rest, context);
+  if (command) {
+    const definition = normalizeCommand(name, command);
+    if (rest[0] === "--help" || rest[0] === "-h") {
+      context.stdout(buildCommandHelp(name, definition));
+      return { exitCode: 0 };
+    }
+    return definition.handler(rest, context);
+  }
 
   if (options.legacyRootCommands?.includes(name)) return options.root(options.argv, context);
 
-  context.stderr(`Unknown command: ${name}`);
+  context.stderr(`Unknown command: ${name}. Run "stasium --help" for usage.`);
   return { exitCode: 1 };
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,37 @@
+export interface CommandContext {
+  stdout: (message: string) => void;
+  stderr: (message: string) => void;
+}
+
+export interface CommandResult {
+  exitCode: number;
+}
+
+export type CommandHandler = (args: string[], context: CommandContext) => Promise<CommandResult>;
+
+export interface RunCommandOptions {
+  argv: string[];
+  stdout?: (message: string) => void;
+  stderr?: (message: string) => void;
+  root: CommandHandler;
+  commands?: Record<string, CommandHandler>;
+  legacyRootCommands?: string[];
+}
+
+export const runCommand = async (options: RunCommandOptions): Promise<CommandResult> => {
+  const [name, ...rest] = options.argv;
+  const context: CommandContext = {
+    stdout: options.stdout ?? console.log,
+    stderr: options.stderr ?? console.error,
+  };
+
+  if (!name) return options.root([], context);
+
+  const command = options.commands?.[name];
+  if (command) return command(rest, context);
+
+  if (options.legacyRootCommands?.includes(name)) return options.root(options.argv, context);
+
+  context.stderr(`Unknown command: ${name}`);
+  return { exitCode: 1 };
+};

--- a/src/update-command.test.ts
+++ b/src/update-command.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runUpdateCommand } from "./update-command";
+import type { CommandContext } from "./cli";
+import type { UpdateDecision } from "./update-channel";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+const updateAvailable = (
+  channel = "stable",
+): Extract<UpdateDecision, { type: "update-available" }> => ({
+  type: "update-available",
+  currentVersion: "0.1.0",
+  latestVersion: "0.2.0",
+  channel,
+  artifact: {
+    platform: { os: "linux", arch: "x64" },
+    name: "stasium-linux-x64",
+    url: "https://example.com/stasium-linux-x64",
+    sha256: "abc123",
+  },
+});
+
+describe("Update Command", () => {
+  test("reports up-to-date releases", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async (channel) => ({ type: "up-to-date", currentVersion: "0.1.0", channel }),
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual(["Stasium 0.1.0 is up to date on stable."]);
+    expect(io.stderr).toEqual([]);
+  });
+
+  test("installs available updates", async () => {
+    const io = context();
+    let installed = false;
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => updateAvailable(),
+      installUpdate: async () => {
+        installed = true;
+        return { type: "installed", path: "/tmp/stasium" };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(installed).toBe(true);
+    expect(io.stdout).toEqual(["Updated Stasium to 0.2.0. Restart Stasium to use it."]);
+  });
+
+  test("checks without installing", async () => {
+    const io = context();
+    let installed = false;
+    const result = await runUpdateCommand(["--check"], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => updateAvailable(),
+      installUpdate: async () => {
+        installed = true;
+        return { type: "installed", path: "/tmp/stasium" };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(installed).toBe(false);
+    expect(io.stdout).toEqual(["Stasium 0.2.0 is available on stable."]);
+  });
+
+  test("overrides the update channel for one run", async () => {
+    const io = context();
+    const channels: string[] = [];
+
+    const result = await runUpdateCommand(["--channel", "nightly", "--check"], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async (channel) => {
+        channels.push(channel);
+        return updateAvailable(channel);
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(channels).toEqual(["nightly"]);
+    expect(io.stdout).toEqual(["Stasium 0.2.0 is available on nightly."]);
+  });
+
+  test("uses the configured update channel by default", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-update-command-"));
+    try {
+      const preferencesPath = join(dir, "update.json");
+      await writeFile(preferencesPath, JSON.stringify({ channel: "beta" }));
+      const io = context();
+      const channels: string[] = [];
+
+      const result = await runUpdateCommand(["--check"], io.context, {
+        currentVersion: "0.1.0",
+        executablePath: "/tmp/stasium",
+        preferencesPath,
+        checkUpdate: async (channel) => {
+          channels.push(channel);
+          return updateAvailable(channel);
+        },
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(channels).toEqual(["beta"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports unsupported platforms as command failures", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => ({
+        type: "unsupported-platform",
+        currentVersion: "0.1.0",
+        latestVersion: "0.2.0",
+        channel: "stable",
+        platform: { os: "linux", arch: "arm64" },
+      }),
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual([
+      "Stasium 0.2.0 is available, but no linux-arm64 artifact was found.",
+    ]);
+  });
+
+  test("reports channel failures as command failures", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => ({
+        type: "failure",
+        currentVersion: "0.1.0",
+        channel: "stable",
+        reason: "network unavailable",
+      }),
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["network unavailable"]);
+  });
+
+  test("reports automatic update failures", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => updateAvailable(),
+      installUpdate: async () => ({ type: "failed", reason: "checksum mismatch" }),
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["Stasium update failed: checksum mismatch"]);
+  });
+});

--- a/src/update-command.ts
+++ b/src/update-command.ts
@@ -1,0 +1,121 @@
+import { defaultSelfUpdateTempDir, SelfUpdateInstaller } from "./self-update";
+import { GitHubUpdateChannel } from "./github-update-channel";
+import { getErrorMessage } from "./shared";
+import { currentUpdatePlatform } from "./startup-update";
+import { defaultUpdatePreferencesPath, loadUpdatePreferences } from "./update-preferences";
+import type { UpdateChannelName, UpdateDecision, UpdatePlatform } from "./update-channel";
+import type { SelfUpdateResult } from "./self-update";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface UpdateCommandOptions {
+  currentVersion: string;
+  executablePath: string;
+  platform?: UpdatePlatform;
+  preferencesPath?: string;
+  checkUpdate?: (channel: UpdateChannelName) => Promise<UpdateDecision>;
+  installUpdate?: (
+    decision: Extract<UpdateDecision, { type: "update-available" }>,
+  ) => Promise<SelfUpdateResult>;
+}
+
+const parseUpdateArgs = (args: string[]): { checkOnly: boolean; channel?: string } => {
+  let checkOnly = false;
+  let channel: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--check") {
+      checkOnly = true;
+      continue;
+    }
+    if (arg === "--channel") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --channel.");
+      channel = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown update option: ${arg}`);
+  }
+
+  return { checkOnly, channel };
+};
+
+const defaultUpdateCheck = (options: UpdateCommandOptions, platform: UpdatePlatform) => {
+  const updateChannel = new GitHubUpdateChannel({ repository: "modoterra/stasium" });
+  return (channel: UpdateChannelName) =>
+    updateChannel.check({ currentVersion: options.currentVersion, channel, platform });
+};
+
+const defaultInstallUpdate = (options: UpdateCommandOptions) => {
+  const installer = new SelfUpdateInstaller({
+    executablePath: options.executablePath,
+    tempDir: defaultSelfUpdateTempDir(options.executablePath),
+  });
+  return (decision: Extract<UpdateDecision, { type: "update-available" }>) =>
+    installer.install(decision.artifact);
+};
+
+export const runUpdateCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: UpdateCommandOptions,
+): Promise<CommandResult> => {
+  let parsed;
+  try {
+    parsed = parseUpdateArgs(args);
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+
+  try {
+    const preferences = await loadUpdatePreferences(
+      options.preferencesPath ?? defaultUpdatePreferencesPath(),
+    );
+    const channel = parsed.channel ?? preferences.channel;
+    const platform = options.platform ?? currentUpdatePlatform();
+    const checkUpdate = options.checkUpdate ?? defaultUpdateCheck(options, platform);
+    const decision = await checkUpdate(channel);
+
+    if (decision.type === "up-to-date") {
+      context.stdout(`Stasium ${decision.currentVersion} is up to date on ${decision.channel}.`);
+      return { exitCode: 0 };
+    }
+
+    if (decision.type === "channel-unavailable" || decision.type === "failure") {
+      context.stderr(decision.reason);
+      return { exitCode: 1 };
+    }
+
+    if (decision.type === "unsupported-platform") {
+      context.stderr(
+        `Stasium ${decision.latestVersion} is available, but no ${decision.platform.os}-${decision.platform.arch} artifact was found.`,
+      );
+      return { exitCode: 1 };
+    }
+
+    if (parsed.checkOnly) {
+      context.stdout(`Stasium ${decision.latestVersion} is available on ${decision.channel}.`);
+      return { exitCode: 0 };
+    }
+
+    const installUpdate = options.installUpdate ?? defaultInstallUpdate(options);
+    const result = await installUpdate(decision);
+    if (result.type === "installed") {
+      context.stdout(`Updated Stasium to ${decision.latestVersion}. Restart Stasium to use it.`);
+      return { exitCode: 0 };
+    }
+    if (result.type === "manual") {
+      context.stdout(`Stasium ${decision.latestVersion} is available: ${result.url}`);
+      context.stderr(`Automatic update unavailable: ${result.reason}`);
+      return { exitCode: 0 };
+    }
+
+    context.stderr(`Stasium update failed: ${result.reason}`);
+    return { exitCode: 1 };
+  } catch (error) {
+    context.stderr(`Stasium update failed: ${getErrorMessage(error)}`);
+    return { exitCode: 1 };
+  }
+};


### PR DESCRIPTION
Closes #132

Stacked on #143.

## Summary

- Added explicit non-interactive `stasium update` command support.
- Added `--check` mode and one-run `--channel <channel>` override.
- Reused existing Update Channel, update preference, platform, and Self Update Installer concepts through an injectable command seam.
- Added command tests for up-to-date, install, check-only, channel override, configured channel, unsupported platform, channel failure, and install failure outcomes.

## Verification

- `bun test src/update-command.test.ts src/cli.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`

## Self Review

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
