### PR TITLE
feat: add project inspection commands

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { ProcessClaimStore } from "./process-claim";
 import { createProjectManifest } from "./project-setup";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
+import { runDiscoverCommand, runDoctorCommand, runValidateCommand } from "./inspection-command";
 import { currentUpdatePlatform, runStartupUpdateCheck } from "./startup-update";
 import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
@@ -972,6 +973,21 @@ export const run = async () => {
             currentVersion: STASIUM_VERSION,
             executablePath: process.argv[0] ?? process.execPath,
           }),
+      },
+      validate: {
+        usage: "stasium validate",
+        description: "Validate the Project Manifest.",
+        handler: runValidateCommand,
+      },
+      doctor: {
+        usage: "stasium doctor",
+        description: "Check Project readiness for Stasium.",
+        handler: runDoctorCommand,
+      },
+      discover: {
+        usage: "stasium discover",
+        description: "Run Discovery and print proposed Process Definitions.",
+        handler: runDiscoverCommand,
       },
     },
   });

--- a/src/inspection-command.test.ts
+++ b/src/inspection-command.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDiscoverCommand, runDoctorCommand, runValidateCommand } from "./inspection-command";
+import { normalizeProcessDefinition } from "./process-definition";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Inspection Commands", () => {
+  test("validates a Manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-validate-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(manifestPath, '[[service]]\nname = "web"\ncommand = "bun dev"\n');
+      const io = context();
+
+      const result = await runValidateCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(io.stdout).toEqual(["Manifest is valid: 1 Process Definition."]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports invalid Manifests", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-validate-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(manifestPath, '[[service]]\nname = "web"\n');
+      const io = context();
+
+      const result = await runValidateCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 1 });
+      expect(io.stderr[0]).toContain("service[0].command");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("checks Project readiness", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-doctor-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(manifestPath, '[[service]]\nname = "web"\ncommand = "bun dev"\n');
+      const io = context();
+
+      const result = await runDoctorCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(io.stdout).toEqual(["Project looks ready."]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports Project readiness problems", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-doctor-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(
+        manifestPath,
+        '[[service]]\nname = "web"\ncommand = "bun dev"\nworking_dir = "missing"\n',
+      );
+      const io = context();
+
+      const result = await runDoctorCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 1 });
+      expect(io.stderr[0]).toBe("Project readiness problems:");
+      expect(io.stderr[1]).toContain("working directory not found");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("prints discovered Candidates without writing a Manifest", async () => {
+    const io = context();
+
+    const result = await runDiscoverCommand([], io.context, {
+      cwd: "/project",
+      detect: async (cwd) => ({
+        candidates: [
+          {
+            strategyId: "web",
+            label: "web",
+            priority: 0,
+            defaultSelected: true,
+            service: normalizeProcessDefinition({
+              name: "web",
+              launchInstruction: ["bun", "dev"],
+            }),
+            dependsOnIds: [],
+          },
+        ],
+        warnings: [`checked ${cwd}`],
+      }),
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual([
+      "Discovered Candidates:",
+      "- web: bun dev",
+      "Warnings:",
+      "- checked /project",
+    ]);
+  });
+});

--- a/src/inspection-command.ts
+++ b/src/inspection-command.ts
@@ -1,0 +1,108 @@
+import { resolve } from "node:path";
+import { stat } from "node:fs/promises";
+import { detectServices, formatServiceSummary, type DetectResult } from "./init";
+import { loadManifest } from "./manifest";
+import { getErrorMessage } from "./shared";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface InspectionCommandOptions {
+  cwd?: string;
+  manifestPath?: string;
+  detect?: (cwd: string) => Promise<DetectResult>;
+  exists?: (path: string) => Promise<boolean>;
+}
+
+const resolveOptions = (options: InspectionCommandOptions) => ({
+  cwd: options.cwd ?? process.cwd(),
+  manifestPath: options.manifestPath ?? resolve(options.cwd ?? process.cwd(), "stasium.toml"),
+  detect: options.detect ?? detectServices,
+  exists: options.exists ?? pathExists,
+});
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const runValidateCommand = async (
+  _args: string[],
+  context: CommandContext,
+  options: InspectionCommandOptions = {},
+): Promise<CommandResult> => {
+  const resolved = resolveOptions(options);
+  try {
+    const manifest = await loadManifest(resolved.manifestPath);
+    context.stdout(
+      `Manifest is valid: ${manifest.services.length} Process Definition${manifest.services.length === 1 ? "" : "s"}.`,
+    );
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runDoctorCommand = async (
+  _args: string[],
+  context: CommandContext,
+  options: InspectionCommandOptions = {},
+): Promise<CommandResult> => {
+  const resolved = resolveOptions(options);
+  try {
+    const manifest = await loadManifest(resolved.manifestPath);
+    const problems: string[] = [];
+
+    for (const processDefinition of manifest.services) {
+      if (!(await resolved.exists(processDefinition.workingDir))) {
+        problems.push(
+          `${processDefinition.name}: working directory not found: ${processDefinition.workingDir}`,
+        );
+      }
+    }
+
+    if (problems.length === 0) {
+      context.stdout("Project looks ready.");
+      return { exitCode: 0 };
+    }
+
+    context.stderr("Project readiness problems:");
+    for (const problem of problems) context.stderr(`- ${problem}`);
+    return { exitCode: 1 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runDiscoverCommand = async (
+  _args: string[],
+  context: CommandContext,
+  options: InspectionCommandOptions = {},
+): Promise<CommandResult> => {
+  const resolved = resolveOptions(options);
+  try {
+    const detected = await resolved.detect(resolved.cwd);
+    if (detected.candidates.length === 0) {
+      context.stdout("No Candidates discovered.");
+    } else {
+      context.stdout("Discovered Candidates:");
+      for (const candidate of detected.candidates) {
+        context.stdout(`- ${formatServiceSummary(candidate.service)}`);
+      }
+    }
+
+    if (detected.warnings.length > 0) {
+      context.stdout("Warnings:");
+      for (const warning of detected.warnings) context.stdout(`- ${warning}`);
+    }
+
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};


### PR DESCRIPTION
Closes #133

Stacked on #144.

## Summary

- Added non-interactive `validate`, `doctor`, and `discover` commands.
- `validate` loads and validates the Project Manifest with script-friendly output.
- `doctor` checks Manifest validity and detectable Project readiness problems such as missing working directories.
- `discover` runs Discovery and prints Candidates without writing a Manifest.

## Verification

- `bun test src/inspection-command.test.ts src/cli.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`

## Self Review

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
