### PR TITLE
feat: add noninteractive project setup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { type KeyEvent, createCliRenderer } from "@opentui/core";
 import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
+import { runInitYesCommand } from "./init-command";
 import {
   addProcessDefinition,
   addSelectedDiscoveryCandidates,
@@ -950,9 +951,12 @@ export const run = async () => {
     },
     commands: {
       init: {
-        usage: "stasium init",
+        usage: "stasium init [--yes]",
         description: "Start explicit Project Setup for this Project.",
         handler: async (args) => {
+          if (args[0] === "--yes") {
+            return runInitYesCommand({ stdout: console.log, stderr: console.error });
+          }
           await runInteractiveApp(["init", ...args]);
           return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
         },

--- a/src/init-command.test.ts
+++ b/src/init-command.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { runInitYesCommand } from "./init-command";
+import { normalizeProcessDefinition } from "./process-definition";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Init Command", () => {
+  test("creates a Manifest from default Candidates", async () => {
+    const io = context();
+    const web = normalizeProcessDefinition({ name: "web", launchInstruction: ["bun", "dev"] });
+    let createdSelectionCount = 0;
+
+    const result = await runInitYesCommand(io.context, {
+      cwd: "/project",
+      manifestPath: "/project/stasium.toml",
+      hasManifest: async () => false,
+      detect: async () => ({
+        candidates: [
+          {
+            strategyId: "web",
+            label: "web",
+            priority: 0,
+            defaultSelected: true,
+            service: web,
+            dependsOnIds: [],
+          },
+        ],
+        warnings: ["discovery warning"],
+      }),
+      createManifest: async (_path, selection) => {
+        createdSelectionCount = selection.getSelectedCount();
+        return { services: [web], warnings: ["selection warning"] };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(createdSelectionCount).toBe(1);
+    expect(io.stdout).toEqual([
+      "Created /project/stasium.toml",
+      "Detected services:",
+      "- web: bun dev",
+      "Warnings:",
+      "- discovery warning",
+      "- selection warning",
+    ]);
+  });
+
+  test("creates an empty Manifest when no Candidates are selected", async () => {
+    const io = context();
+
+    const result = await runInitYesCommand(io.context, {
+      manifestPath: "/project/stasium.toml",
+      hasManifest: async () => false,
+      detect: async () => ({ candidates: [], warnings: [] }),
+      createManifest: async () => ({ services: [], warnings: [] }),
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual([
+      "Created /project/stasium.toml",
+      "No services selected. Edit stasium.toml to add services.",
+    ]);
+  });
+
+  test("does not overwrite an existing Manifest", async () => {
+    const io = context();
+    let detected = false;
+
+    const result = await runInitYesCommand(io.context, {
+      manifestPath: "/project/stasium.toml",
+      hasManifest: async () => true,
+      detect: async () => {
+        detected = true;
+        return { candidates: [], warnings: [] };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(detected).toBe(false);
+    expect(io.stderr).toEqual(["Manifest already exists: /project/stasium.toml"]);
+  });
+});

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -1,0 +1,59 @@
+import { resolve } from "node:path";
+import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
+import { createProjectManifest, type ProjectSetupResult } from "./project-setup";
+import { fileExists, getErrorMessage } from "./shared";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface InitYesCommandOptions {
+  cwd?: string;
+  manifestPath?: string;
+  hasManifest?: (path: string) => Promise<boolean>;
+  detect?: typeof detectServices;
+  createManifest?: (
+    manifestPath: string,
+    selection: DiscoverySelection,
+  ) => Promise<ProjectSetupResult>;
+}
+
+export const runInitYesCommand = async (
+  context: CommandContext,
+  options: InitYesCommandOptions = {},
+): Promise<CommandResult> => {
+  const cwd = options.cwd ?? process.cwd();
+  const manifestPath = options.manifestPath ?? resolve(cwd, "stasium.toml");
+  const hasManifest = options.hasManifest ?? fileExists;
+
+  if (await hasManifest(manifestPath)) {
+    context.stderr(`Manifest already exists: ${manifestPath}`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    const detected = await (options.detect ?? detectServices)(cwd);
+    const selection = new DiscoverySelection(detected.candidates);
+    const finalized = await (options.createManifest ?? createProjectManifest)(
+      manifestPath,
+      selection,
+    );
+
+    context.stdout(`Created ${manifestPath}`);
+    if (finalized.services.length > 0) {
+      context.stdout("Detected services:");
+      for (const service of finalized.services)
+        context.stdout(`- ${formatServiceSummary(service)}`);
+    } else {
+      context.stdout("No services selected. Edit stasium.toml to add services.");
+    }
+
+    const warnings = [...detected.warnings, ...finalized.warnings];
+    if (warnings.length > 0) {
+      context.stdout("Warnings:");
+      for (const warning of warnings) context.stdout(`- ${warning}`);
+    }
+
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};


### PR DESCRIPTION
Closes #135

Stacked on #145.

## Summary

- Added `stasium init --yes` for non-interactive Project Setup.
- Reused Discovery default Candidate Selection and existing Manifest creation behavior.
- Added plain terminal output for created Process Definitions, empty setup, warnings, and existing-Manifest failures.

## Verification

- `bun test src/init-command.test.ts src/cli.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`

## Self Review

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
