### PR TITLE
feat: add lifecycle stop and restart commands

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { type KeyEvent, createCliRenderer } from "@opentui/core";
+import { runConfigCommand } from "./config-command";
 import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
@@ -992,6 +993,11 @@ export const run = async () => {
         usage: "stasium discover",
         description: "Run Discovery and print proposed Process Definitions.",
         handler: runDiscoverCommand,
+      },
+      config: {
+        usage: "stasium config <get|set> <key> [value]",
+        description: "Read or write supported Stasium preferences.",
+        handler: runConfigCommand,
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -941,14 +941,27 @@ const runInteractiveApp = async (args: string[]): Promise<void> => {
 export const run = async () => {
   const result = await runCommand({
     argv: process.argv.slice(2),
+    version: STASIUM_VERSION,
     root: async (args) => {
       await runInteractiveApp(args);
       return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
     },
     commands: {
-      init: async (args) => {
-        await runInteractiveApp(["init", ...args]);
-        return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+      init: {
+        usage: "stasium init",
+        description: "Start explicit Project Setup for this Project.",
+        handler: async (args) => {
+          await runInteractiveApp(["init", ...args]);
+          return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+        },
+      },
+      version: {
+        usage: "stasium version",
+        description: "Print the installed Stasium version.",
+        handler: async (_args, context) => {
+          context.stdout(STASIUM_VERSION);
+          return { exitCode: 0 };
+        },
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
 import { runInitYesCommand } from "./init-command";
+import { runStartCommand, runStatusCommand } from "./lifecycle-command";
 import {
   addProcessDefinition,
   addSelectedDiscoveryCandidates,
@@ -998,6 +999,16 @@ export const run = async () => {
         usage: "stasium config <get|set> <key> [value]",
         description: "Read or write supported Stasium preferences.",
         handler: runConfigCommand,
+      },
+      start: {
+        usage: "stasium start [managed-process-name]",
+        description: "Start Direct Managed Processes without opening the Workspace.",
+        handler: runStartCommand,
+      },
+      status: {
+        usage: "stasium status",
+        description: "Print known Managed Process state.",
+        handler: runStatusCommand,
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
 import { STASIUM_VERSION } from "./version";
 import { startWorkspace, type ShutdownController } from "./workspace-startup";
+import { runCommand } from "./cli";
 
 const MANIFEST_PATH = "stasium.toml";
 
@@ -795,8 +796,7 @@ const startInitFlow = (
   })();
 };
 
-export const run = async () => {
-  const args = process.argv.slice(2);
+const runInteractiveApp = async (args: string[]): Promise<void> => {
   const hasManifest = await fileExists(MANIFEST_PATH);
   const teardownRef: { current: (() => void) | null } = { current: null };
   const shutdownRef: { current: ShutdownController | null } = { current: null };
@@ -936,4 +936,17 @@ export const run = async () => {
   });
 
   renderer.start();
+};
+
+export const run = async () => {
+  const result = await runCommand({
+    argv: process.argv.slice(2),
+    legacyRootCommands: ["init"],
+    root: async (args) => {
+      await runInteractiveApp(args);
+      return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+    },
+  });
+
+  process.exitCode = result.exitCode;
 };

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,12 @@ import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
 import { runInitYesCommand } from "./init-command";
-import { runStartCommand, runStatusCommand } from "./lifecycle-command";
+import {
+  runRestartCommand,
+  runStartCommand,
+  runStatusCommand,
+  runStopCommand,
+} from "./lifecycle-command";
 import {
   addProcessDefinition,
   addSelectedDiscoveryCandidates,
@@ -1009,6 +1014,16 @@ export const run = async () => {
         usage: "stasium status",
         description: "Print known Managed Process state.",
         handler: runStatusCommand,
+      },
+      stop: {
+        usage: "stasium stop [managed-process-name]",
+        description: "Stop Direct Managed Processes using Process Claims.",
+        handler: runStopCommand,
+      },
+      restart: {
+        usage: "stasium restart [managed-process-name]",
+        description: "Restart Direct Managed Processes without opening the Workspace.",
+        handler: runRestartCommand,
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { type KeyEvent, createCliRenderer } from "@opentui/core";
 import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
+import { runInitYesCommand } from "./init-command";
 import {
   addProcessDefinition,
   addSelectedDiscoveryCandidates,
@@ -950,9 +951,12 @@ export const run = async () => {
     },
     commands: {
       init: {
-        usage: "stasium init",
+        usage: "stasium init [--yes]",
         description: "Start explicit Project Setup for this Project.",
         handler: async (args) => {
+          if (args[0] === "--yes") {
+            return runInitYesCommand({ stdout: console.log, stderr: console.error });
+          }
           await runInteractiveApp(["init", ...args]);
           return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
         },

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,6 +17,7 @@ import { fileExists, getErrorMessage } from "./shared";
 import { currentUpdatePlatform, runStartupUpdateCheck } from "./startup-update";
 import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
+import { runUpdateCommand } from "./update-command";
 import { STASIUM_VERSION } from "./version";
 import { startWorkspace, type ShutdownController } from "./workspace-startup";
 import { runCommand } from "./cli";
@@ -962,6 +963,15 @@ export const run = async () => {
           context.stdout(STASIUM_VERSION);
           return { exitCode: 0 };
         },
+      },
+      update: {
+        usage: "stasium update [--check] [--channel <channel>]",
+        description: "Check for and install a Stasium update.",
+        handler: (args, context) =>
+          runUpdateCommand(args, context, {
+            currentVersion: STASIUM_VERSION,
+            executablePath: process.argv[0] ?? process.execPath,
+          }),
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { ProcessClaimStore } from "./process-claim";
 import { createProjectManifest } from "./project-setup";
 import { ServiceManager } from "./service-manager";
 import { fileExists, getErrorMessage } from "./shared";
+import { runDiscoverCommand, runDoctorCommand, runValidateCommand } from "./inspection-command";
 import { currentUpdatePlatform, runStartupUpdateCheck } from "./startup-update";
 import type { AppConfig, Manifest, Shortcut } from "./types";
 import { type UiControls, buildInitUi, buildUi } from "./ui";
@@ -972,6 +973,21 @@ export const run = async () => {
             currentVersion: STASIUM_VERSION,
             executablePath: process.argv[0] ?? process.execPath,
           }),
+      },
+      validate: {
+        usage: "stasium validate",
+        description: "Validate the Project Manifest.",
+        handler: runValidateCommand,
+      },
+      doctor: {
+        usage: "stasium doctor",
+        description: "Check Project readiness for Stasium.",
+        handler: runDoctorCommand,
+      },
+      discover: {
+        usage: "stasium discover",
+        description: "Run Discovery and print proposed Process Definitions.",
+        handler: runDiscoverCommand,
       },
     },
   });

--- a/src/app.ts
+++ b/src/app.ts
@@ -941,10 +941,15 @@ const runInteractiveApp = async (args: string[]): Promise<void> => {
 export const run = async () => {
   const result = await runCommand({
     argv: process.argv.slice(2),
-    legacyRootCommands: ["init"],
     root: async (args) => {
       await runInteractiveApp(args);
       return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+    },
+    commands: {
+      init: async (args) => {
+        await runInteractiveApp(["init", ...args]);
+        return { exitCode: typeof process.exitCode === "number" ? process.exitCode : 0 };
+      },
     },
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { runCommand, type CommandContext, type CommandResult } from "./cli";
+
+const noopContextHandler = async (): Promise<CommandResult> => ({ exitCode: 0 });
+
+describe("Command Runner", () => {
+  test("delegates the root command when no argv is provided", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: [],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 0 };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([[]]);
+  });
+
+  test("dispatches registered non-root commands with injected output", async () => {
+    const stdout: string[] = [];
+    const contexts: CommandContext[] = [];
+
+    const result = await runCommand({
+      argv: ["example", "--flag"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        example: async (args, context) => {
+          contexts.push(context);
+          context.stdout(args.join(" "));
+          return { exitCode: 7 };
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 7 });
+    expect(stdout).toEqual(["--flag"]);
+    expect(contexts).toHaveLength(1);
+  });
+
+  test("passes legacy root commands to the root handler", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: ["init"],
+      legacyRootCommands: ["init"],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 0 };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([["init"]]);
+  });
+
+  test("returns a command failure for unknown commands", async () => {
+    const stderr: string[] = [];
+
+    const result = await runCommand({
+      argv: ["wat"],
+      stderr: (message) => stderr.push(message),
+      root: noopContextHandler,
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(stderr).toEqual(["Unknown command: wat"]);
+  });
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -88,6 +88,82 @@ describe("Command Runner", () => {
     });
 
     expect(result).toEqual({ exitCode: 1 });
-    expect(stderr).toEqual(["Unknown command: wat"]);
+    expect(stderr).toEqual(['Unknown command: wat. Run "stasium --help" for usage.']);
+  });
+
+  test("prints root help without running the root handler", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["--help"],
+      stdout: (message) => stdout.push(message),
+      root: async () => ({ exitCode: 1 }),
+      commands: {
+        init: {
+          usage: "stasium init",
+          description: "Start Project Setup.",
+          handler: noopContextHandler,
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout[0]).toContain("Usage: stasium [command]");
+    expect(stdout[0]).toContain("Run Stasium's interactive Workspace");
+    expect(stdout[0]).toContain("init  Start Project Setup.");
+  });
+
+  test("prints command help", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["help", "init"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        init: {
+          usage: "stasium init",
+          description: "Start Project Setup.",
+          handler: noopContextHandler,
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout).toEqual(["stasium init\n\nStart Project Setup."]);
+  });
+
+  test("prints command help from command flags", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["init", "--help"],
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+      commands: {
+        init: {
+          usage: "stasium init",
+          description: "Start Project Setup.",
+          handler: noopContextHandler,
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout).toEqual(["stasium init\n\nStart Project Setup."]);
+  });
+
+  test("prints version output", async () => {
+    const stdout: string[] = [];
+
+    const result = await runCommand({
+      argv: ["--version"],
+      version: "1.2.3",
+      stdout: (message) => stdout.push(message),
+      root: noopContextHandler,
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(stdout).toEqual(["1.2.3"]);
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -41,12 +41,33 @@ describe("Command Runner", () => {
     expect(contexts).toHaveLength(1);
   });
 
-  test("passes legacy root commands to the root handler", async () => {
+  test("dispatches registered commands instead of the root handler", async () => {
     const calls: string[][] = [];
 
     const result = await runCommand({
       argv: ["init"],
-      legacyRootCommands: ["init"],
+      root: async (args) => {
+        calls.push(args);
+        return { exitCode: 1 };
+      },
+      commands: {
+        init: async (args) => {
+          calls.push(["init", ...args]);
+          return { exitCode: 0 };
+        },
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([["init"]]);
+  });
+
+  test("can temporarily pass legacy root commands to the root handler", async () => {
+    const calls: string[][] = [];
+
+    const result = await runCommand({
+      argv: ["legacy"],
+      legacyRootCommands: ["legacy"],
       root: async (args) => {
         calls.push(args);
         return { exitCode: 0 };
@@ -54,7 +75,7 @@ describe("Command Runner", () => {
     });
 
     expect(result).toEqual({ exitCode: 0 });
-    expect(calls).toEqual([["init"]]);
+    expect(calls).toEqual([["legacy"]]);
   });
 
   test("returns a command failure for unknown commands", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,14 +9,56 @@ export interface CommandResult {
 
 export type CommandHandler = (args: string[], context: CommandContext) => Promise<CommandResult>;
 
+export interface CommandDefinition {
+  description: string;
+  usage: string;
+  handler: CommandHandler;
+}
+
 export interface RunCommandOptions {
   argv: string[];
   stdout?: (message: string) => void;
   stderr?: (message: string) => void;
   root: CommandHandler;
-  commands?: Record<string, CommandHandler>;
+  rootUsage?: string;
+  rootDescription?: string;
+  version?: string;
+  commands?: Record<string, CommandHandler | CommandDefinition>;
   legacyRootCommands?: string[];
 }
+
+const normalizeCommand = (
+  name: string,
+  command: CommandHandler | CommandDefinition,
+): CommandDefinition => {
+  if (typeof command === "function") {
+    return { usage: `stasium ${name}`, description: "", handler: command };
+  }
+  return command;
+};
+
+const buildRootHelp = (options: RunCommandOptions): string => {
+  const lines = [
+    options.rootUsage ?? "Usage: stasium [command]",
+    "",
+    options.rootDescription ??
+      "Run Stasium's interactive Workspace, or start Project Setup when no Manifest exists.",
+  ];
+
+  const entries = Object.entries(options.commands ?? {});
+  if (entries.length > 0) {
+    lines.push("", "Commands:");
+    for (const [name, command] of entries) {
+      const definition = normalizeCommand(name, command);
+      lines.push(`  ${name}${definition.description ? `  ${definition.description}` : ""}`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+const buildCommandHelp = (name: string, command: CommandDefinition): string =>
+  command.description ? `${command.usage}\n\n${command.description}` : command.usage;
 
 export const runCommand = async (options: RunCommandOptions): Promise<CommandResult> => {
   const [name, ...rest] = options.argv;
@@ -27,11 +69,45 @@ export const runCommand = async (options: RunCommandOptions): Promise<CommandRes
 
   if (!name) return options.root([], context);
 
+  if (name === "--help" || name === "-h") {
+    context.stdout(buildRootHelp(options));
+    return { exitCode: 0 };
+  }
+
+  if ((name === "--version" || name === "-v") && options.version) {
+    context.stdout(options.version);
+    return { exitCode: 0 };
+  }
+
+  if (name === "help") {
+    const [target] = rest;
+    if (!target) {
+      context.stdout(buildRootHelp(options));
+      return { exitCode: 0 };
+    }
+
+    const command = options.commands?.[target];
+    if (!command) {
+      context.stderr(`Unknown command: ${target}`);
+      return { exitCode: 1 };
+    }
+
+    context.stdout(buildCommandHelp(target, normalizeCommand(target, command)));
+    return { exitCode: 0 };
+  }
+
   const command = options.commands?.[name];
-  if (command) return command(rest, context);
+  if (command) {
+    const definition = normalizeCommand(name, command);
+    if (rest[0] === "--help" || rest[0] === "-h") {
+      context.stdout(buildCommandHelp(name, definition));
+      return { exitCode: 0 };
+    }
+    return definition.handler(rest, context);
+  }
 
   if (options.legacyRootCommands?.includes(name)) return options.root(options.argv, context);
 
-  context.stderr(`Unknown command: ${name}`);
+  context.stderr(`Unknown command: ${name}. Run "stasium --help" for usage.`);
   return { exitCode: 1 };
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,37 @@
+export interface CommandContext {
+  stdout: (message: string) => void;
+  stderr: (message: string) => void;
+}
+
+export interface CommandResult {
+  exitCode: number;
+}
+
+export type CommandHandler = (args: string[], context: CommandContext) => Promise<CommandResult>;
+
+export interface RunCommandOptions {
+  argv: string[];
+  stdout?: (message: string) => void;
+  stderr?: (message: string) => void;
+  root: CommandHandler;
+  commands?: Record<string, CommandHandler>;
+  legacyRootCommands?: string[];
+}
+
+export const runCommand = async (options: RunCommandOptions): Promise<CommandResult> => {
+  const [name, ...rest] = options.argv;
+  const context: CommandContext = {
+    stdout: options.stdout ?? console.log,
+    stderr: options.stderr ?? console.error,
+  };
+
+  if (!name) return options.root([], context);
+
+  const command = options.commands?.[name];
+  if (command) return command(rest, context);
+
+  if (options.legacyRootCommands?.includes(name)) return options.root(options.argv, context);
+
+  context.stderr(`Unknown command: ${name}`);
+  return { exitCode: 1 };
+};

--- a/src/config-command.test.ts
+++ b/src/config-command.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runConfigCommand } from "./config-command";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Config Command", () => {
+  test("gets default update preferences", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-config-"));
+    try {
+      const io = context();
+      const result = await runConfigCommand(["get", "update.channel"], io.context, {
+        preferencesPath: join(dir, "update.json"),
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(io.stdout).toEqual(["stable"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("sets and persists update channel", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-config-"));
+    try {
+      const path = join(dir, "update.json");
+      const io = context();
+
+      const result = await runConfigCommand(["set", "update.channel", "beta"], io.context, {
+        preferencesPath: path,
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(io.stdout).toEqual(["Set update.channel to beta."]);
+      expect(JSON.parse(await readFile(path, "utf8"))).toMatchObject({ channel: "beta" });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("gets and sets update enabled", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-config-"));
+    try {
+      const path = join(dir, "update.json");
+      const setIo = context();
+      const getIo = context();
+
+      expect(
+        await runConfigCommand(["set", "update.enabled", "false"], setIo.context, {
+          preferencesPath: path,
+        }),
+      ).toEqual({ exitCode: 0 });
+      expect(
+        await runConfigCommand(["get", "update.enabled"], getIo.context, {
+          preferencesPath: path,
+        }),
+      ).toEqual({ exitCode: 0 });
+      expect(getIo.stdout).toEqual(["false"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects invalid boolean values", async () => {
+    const io = context();
+    const result = await runConfigCommand(["set", "update.enabled", "maybe"], io.context);
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["update.enabled must be true or false."]);
+  });
+
+  test("rejects unsupported keys", async () => {
+    const io = context();
+    const result = await runConfigCommand(["get", "theme"], io.context);
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual([
+      "Unsupported config key: theme. Supported keys: update.channel, update.enabled.",
+    ]);
+  });
+});

--- a/src/config-command.ts
+++ b/src/config-command.ts
@@ -1,0 +1,74 @@
+import {
+  defaultUpdatePreferencesPath,
+  loadUpdatePreferences,
+  saveUpdatePreferences,
+} from "./update-preferences";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface ConfigCommandOptions {
+  preferencesPath?: string;
+}
+
+const supportedKeys = ["update.channel", "update.enabled"];
+
+const unsupportedKey = (context: CommandContext, key: string): CommandResult => {
+  context.stderr(`Unsupported config key: ${key}. Supported keys: ${supportedKeys.join(", ")}.`);
+  return { exitCode: 1 };
+};
+
+const parseBoolean = (value: string): boolean | null => {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+};
+
+export const runConfigCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: ConfigCommandOptions = {},
+): Promise<CommandResult> => {
+  const [action, key, value] = args;
+  const preferencesPath = options.preferencesPath ?? defaultUpdatePreferencesPath();
+
+  if (action !== "get" && action !== "set") {
+    context.stderr("Usage: stasium config <get|set> <key> [value]");
+    return { exitCode: 1 };
+  }
+  if (!key) {
+    context.stderr("Missing config key.");
+    return { exitCode: 1 };
+  }
+  if (!supportedKeys.includes(key)) return unsupportedKey(context, key);
+
+  const preferences = await loadUpdatePreferences(preferencesPath);
+
+  if (action === "get") {
+    if (value !== undefined) {
+      context.stderr("Config get does not accept a value.");
+      return { exitCode: 1 };
+    }
+    context.stdout(key === "update.channel" ? preferences.channel : String(preferences.enabled));
+    return { exitCode: 0 };
+  }
+
+  if (value === undefined) {
+    context.stderr(`Missing value for ${key}.`);
+    return { exitCode: 1 };
+  }
+
+  if (key === "update.channel") {
+    await saveUpdatePreferences({ ...preferences, channel: value }, preferencesPath);
+    context.stdout(`Set update.channel to ${value}.`);
+    return { exitCode: 0 };
+  }
+
+  const enabled = parseBoolean(value);
+  if (enabled === null) {
+    context.stderr("update.enabled must be true or false.");
+    return { exitCode: 1 };
+  }
+
+  await saveUpdatePreferences({ ...preferences, enabled }, preferencesPath);
+  context.stdout(`Set update.enabled to ${enabled}.`);
+  return { exitCode: 0 };
+};

--- a/src/init-command.test.ts
+++ b/src/init-command.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { runInitYesCommand } from "./init-command";
+import { normalizeProcessDefinition } from "./process-definition";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Init Command", () => {
+  test("creates a Manifest from default Candidates", async () => {
+    const io = context();
+    const web = normalizeProcessDefinition({ name: "web", launchInstruction: ["bun", "dev"] });
+    let createdSelectionCount = 0;
+
+    const result = await runInitYesCommand(io.context, {
+      cwd: "/project",
+      manifestPath: "/project/stasium.toml",
+      hasManifest: async () => false,
+      detect: async () => ({
+        candidates: [
+          {
+            strategyId: "web",
+            label: "web",
+            priority: 0,
+            defaultSelected: true,
+            service: web,
+            dependsOnIds: [],
+          },
+        ],
+        warnings: ["discovery warning"],
+      }),
+      createManifest: async (_path, selection) => {
+        createdSelectionCount = selection.getSelectedCount();
+        return { services: [web], warnings: ["selection warning"] };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(createdSelectionCount).toBe(1);
+    expect(io.stdout).toEqual([
+      "Created /project/stasium.toml",
+      "Detected services:",
+      "- web: bun dev",
+      "Warnings:",
+      "- discovery warning",
+      "- selection warning",
+    ]);
+  });
+
+  test("creates an empty Manifest when no Candidates are selected", async () => {
+    const io = context();
+
+    const result = await runInitYesCommand(io.context, {
+      manifestPath: "/project/stasium.toml",
+      hasManifest: async () => false,
+      detect: async () => ({ candidates: [], warnings: [] }),
+      createManifest: async () => ({ services: [], warnings: [] }),
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual([
+      "Created /project/stasium.toml",
+      "No services selected. Edit stasium.toml to add services.",
+    ]);
+  });
+
+  test("does not overwrite an existing Manifest", async () => {
+    const io = context();
+    let detected = false;
+
+    const result = await runInitYesCommand(io.context, {
+      manifestPath: "/project/stasium.toml",
+      hasManifest: async () => true,
+      detect: async () => {
+        detected = true;
+        return { candidates: [], warnings: [] };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(detected).toBe(false);
+    expect(io.stderr).toEqual(["Manifest already exists: /project/stasium.toml"]);
+  });
+});

--- a/src/init-command.ts
+++ b/src/init-command.ts
@@ -1,0 +1,59 @@
+import { resolve } from "node:path";
+import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
+import { createProjectManifest, type ProjectSetupResult } from "./project-setup";
+import { fileExists, getErrorMessage } from "./shared";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface InitYesCommandOptions {
+  cwd?: string;
+  manifestPath?: string;
+  hasManifest?: (path: string) => Promise<boolean>;
+  detect?: typeof detectServices;
+  createManifest?: (
+    manifestPath: string,
+    selection: DiscoverySelection,
+  ) => Promise<ProjectSetupResult>;
+}
+
+export const runInitYesCommand = async (
+  context: CommandContext,
+  options: InitYesCommandOptions = {},
+): Promise<CommandResult> => {
+  const cwd = options.cwd ?? process.cwd();
+  const manifestPath = options.manifestPath ?? resolve(cwd, "stasium.toml");
+  const hasManifest = options.hasManifest ?? fileExists;
+
+  if (await hasManifest(manifestPath)) {
+    context.stderr(`Manifest already exists: ${manifestPath}`);
+    return { exitCode: 1 };
+  }
+
+  try {
+    const detected = await (options.detect ?? detectServices)(cwd);
+    const selection = new DiscoverySelection(detected.candidates);
+    const finalized = await (options.createManifest ?? createProjectManifest)(
+      manifestPath,
+      selection,
+    );
+
+    context.stdout(`Created ${manifestPath}`);
+    if (finalized.services.length > 0) {
+      context.stdout("Detected services:");
+      for (const service of finalized.services)
+        context.stdout(`- ${formatServiceSummary(service)}`);
+    } else {
+      context.stdout("No services selected. Edit stasium.toml to add services.");
+    }
+
+    const warnings = [...detected.warnings, ...finalized.warnings];
+    if (warnings.length > 0) {
+      context.stdout("Warnings:");
+      for (const warning of warnings) context.stdout(`- ${warning}`);
+    }
+
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};

--- a/src/inspection-command.test.ts
+++ b/src/inspection-command.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runDiscoverCommand, runDoctorCommand, runValidateCommand } from "./inspection-command";
+import { normalizeProcessDefinition } from "./process-definition";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Inspection Commands", () => {
+  test("validates a Manifest", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-validate-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(manifestPath, '[[service]]\nname = "web"\ncommand = "bun dev"\n');
+      const io = context();
+
+      const result = await runValidateCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(io.stdout).toEqual(["Manifest is valid: 1 Process Definition."]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports invalid Manifests", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-validate-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(manifestPath, '[[service]]\nname = "web"\n');
+      const io = context();
+
+      const result = await runValidateCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 1 });
+      expect(io.stderr[0]).toContain("service[0].command");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("checks Project readiness", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-doctor-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(manifestPath, '[[service]]\nname = "web"\ncommand = "bun dev"\n');
+      const io = context();
+
+      const result = await runDoctorCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(io.stdout).toEqual(["Project looks ready."]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports Project readiness problems", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-doctor-"));
+    try {
+      const manifestPath = join(dir, "stasium.toml");
+      await writeFile(
+        manifestPath,
+        '[[service]]\nname = "web"\ncommand = "bun dev"\nworking_dir = "missing"\n',
+      );
+      const io = context();
+
+      const result = await runDoctorCommand([], io.context, { manifestPath });
+
+      expect(result).toEqual({ exitCode: 1 });
+      expect(io.stderr[0]).toBe("Project readiness problems:");
+      expect(io.stderr[1]).toContain("working directory not found");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("prints discovered Candidates without writing a Manifest", async () => {
+    const io = context();
+
+    const result = await runDiscoverCommand([], io.context, {
+      cwd: "/project",
+      detect: async (cwd) => ({
+        candidates: [
+          {
+            strategyId: "web",
+            label: "web",
+            priority: 0,
+            defaultSelected: true,
+            service: normalizeProcessDefinition({
+              name: "web",
+              launchInstruction: ["bun", "dev"],
+            }),
+            dependsOnIds: [],
+          },
+        ],
+        warnings: [`checked ${cwd}`],
+      }),
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual([
+      "Discovered Candidates:",
+      "- web: bun dev",
+      "Warnings:",
+      "- checked /project",
+    ]);
+  });
+});

--- a/src/inspection-command.ts
+++ b/src/inspection-command.ts
@@ -1,0 +1,108 @@
+import { resolve } from "node:path";
+import { stat } from "node:fs/promises";
+import { detectServices, formatServiceSummary, type DetectResult } from "./init";
+import { loadManifest } from "./manifest";
+import { getErrorMessage } from "./shared";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface InspectionCommandOptions {
+  cwd?: string;
+  manifestPath?: string;
+  detect?: (cwd: string) => Promise<DetectResult>;
+  exists?: (path: string) => Promise<boolean>;
+}
+
+const resolveOptions = (options: InspectionCommandOptions) => ({
+  cwd: options.cwd ?? process.cwd(),
+  manifestPath: options.manifestPath ?? resolve(options.cwd ?? process.cwd(), "stasium.toml"),
+  detect: options.detect ?? detectServices,
+  exists: options.exists ?? pathExists,
+});
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const runValidateCommand = async (
+  _args: string[],
+  context: CommandContext,
+  options: InspectionCommandOptions = {},
+): Promise<CommandResult> => {
+  const resolved = resolveOptions(options);
+  try {
+    const manifest = await loadManifest(resolved.manifestPath);
+    context.stdout(
+      `Manifest is valid: ${manifest.services.length} Process Definition${manifest.services.length === 1 ? "" : "s"}.`,
+    );
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runDoctorCommand = async (
+  _args: string[],
+  context: CommandContext,
+  options: InspectionCommandOptions = {},
+): Promise<CommandResult> => {
+  const resolved = resolveOptions(options);
+  try {
+    const manifest = await loadManifest(resolved.manifestPath);
+    const problems: string[] = [];
+
+    for (const processDefinition of manifest.services) {
+      if (!(await resolved.exists(processDefinition.workingDir))) {
+        problems.push(
+          `${processDefinition.name}: working directory not found: ${processDefinition.workingDir}`,
+        );
+      }
+    }
+
+    if (problems.length === 0) {
+      context.stdout("Project looks ready.");
+      return { exitCode: 0 };
+    }
+
+    context.stderr("Project readiness problems:");
+    for (const problem of problems) context.stderr(`- ${problem}`);
+    return { exitCode: 1 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runDiscoverCommand = async (
+  _args: string[],
+  context: CommandContext,
+  options: InspectionCommandOptions = {},
+): Promise<CommandResult> => {
+  const resolved = resolveOptions(options);
+  try {
+    const detected = await resolved.detect(resolved.cwd);
+    if (detected.candidates.length === 0) {
+      context.stdout("No Candidates discovered.");
+    } else {
+      context.stdout("Discovered Candidates:");
+      for (const candidate of detected.candidates) {
+        context.stdout(`- ${formatServiceSummary(candidate.service)}`);
+      }
+    }
+
+    if (detected.warnings.length > 0) {
+      context.stdout("Warnings:");
+      for (const warning of detected.warnings) context.stdout(`- ${warning}`);
+    }
+
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};

--- a/src/lifecycle-command.test.ts
+++ b/src/lifecycle-command.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { runStartCommand, runStatusCommand, type LifecycleOperations } from "./lifecycle-command";
+import {
+  runRestartCommand,
+  runStartCommand,
+  runStatusCommand,
+  runStopCommand,
+  type LifecycleOperations,
+} from "./lifecycle-command";
 import type { CommandContext } from "./cli";
 
 const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
@@ -24,6 +30,8 @@ describe("Lifecycle Commands", () => {
         calls.push(name);
         return ["web", "worker"];
       },
+      stop: async () => [],
+      restart: async () => [],
       status: async () => [],
     };
 
@@ -42,6 +50,8 @@ describe("Lifecycle Commands", () => {
         calls.push(name);
         return ["web"];
       },
+      stop: async () => [],
+      restart: async () => [],
       status: async () => [],
     };
 
@@ -58,6 +68,8 @@ describe("Lifecycle Commands", () => {
       start: async () => {
         throw new Error("Unknown Managed Process: missing");
       },
+      stop: async () => [],
+      restart: async () => [],
       status: async () => [],
     };
 
@@ -71,6 +83,8 @@ describe("Lifecycle Commands", () => {
     const io = context();
     const operations: LifecycleOperations = {
       start: async () => [],
+      stop: async () => [],
+      restart: async () => [],
       status: async () => [
         { name: "web", state: "RUNNING" },
         { name: "worker", state: "STOPPED" },
@@ -81,5 +95,45 @@ describe("Lifecycle Commands", () => {
 
     expect(result).toEqual({ exitCode: 0 });
     expect(io.stdout).toEqual(["web: RUNNING", "worker: STOPPED"]);
+  });
+
+  test("stops Direct Managed Processes", async () => {
+    const io = context();
+    const calls: Array<string | undefined> = [];
+    const operations: LifecycleOperations = {
+      start: async () => [],
+      stop: async (name) => {
+        calls.push(name);
+        return ["web"];
+      },
+      restart: async () => [],
+      status: async () => [],
+    };
+
+    const result = await runStopCommand(["web"], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual(["web"]);
+    expect(io.stdout).toEqual(["Stopped web."]);
+  });
+
+  test("restarts Direct Managed Processes", async () => {
+    const io = context();
+    const calls: Array<string | undefined> = [];
+    const operations: LifecycleOperations = {
+      start: async () => [],
+      stop: async () => [],
+      restart: async (name) => {
+        calls.push(name);
+        return ["web"];
+      },
+      status: async () => [],
+    };
+
+    const result = await runRestartCommand(["web"], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual(["web"]);
+    expect(io.stdout).toEqual(["Restarted web."]);
   });
 });

--- a/src/lifecycle-command.test.ts
+++ b/src/lifecycle-command.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { runStartCommand, runStatusCommand, type LifecycleOperations } from "./lifecycle-command";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Lifecycle Commands", () => {
+  test("starts all Direct Managed Processes", async () => {
+    const io = context();
+    const calls: Array<string | undefined> = [];
+    const operations: LifecycleOperations = {
+      start: async (name) => {
+        calls.push(name);
+        return ["web", "worker"];
+      },
+      status: async () => [],
+    };
+
+    const result = await runStartCommand([], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([undefined]);
+    expect(io.stdout).toEqual(["Started web.", "Started worker."]);
+  });
+
+  test("starts one named Direct Managed Process", async () => {
+    const io = context();
+    const calls: Array<string | undefined> = [];
+    const operations: LifecycleOperations = {
+      start: async (name) => {
+        calls.push(name);
+        return ["web"];
+      },
+      status: async () => [],
+    };
+
+    const result = await runStartCommand(["web"], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual(["web"]);
+    expect(io.stdout).toEqual(["Started web."]);
+  });
+
+  test("reports unknown Managed Process names", async () => {
+    const io = context();
+    const operations: LifecycleOperations = {
+      start: async () => {
+        throw new Error("Unknown Managed Process: missing");
+      },
+      status: async () => [],
+    };
+
+    const result = await runStartCommand(["missing"], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["Unknown Managed Process: missing"]);
+  });
+
+  test("prints Managed Process status", async () => {
+    const io = context();
+    const operations: LifecycleOperations = {
+      start: async () => [],
+      status: async () => [
+        { name: "web", state: "RUNNING" },
+        { name: "worker", state: "STOPPED" },
+      ],
+    };
+
+    const result = await runStatusCommand([], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual(["web: RUNNING", "worker: STOPPED"]);
+  });
+});

--- a/src/lifecycle-command.ts
+++ b/src/lifecycle-command.ts
@@ -1,0 +1,106 @@
+import { resolve } from "node:path";
+import { loadManifest } from "./manifest";
+import { ProcessClaimStore } from "./process-claim";
+import { ServiceManager } from "./service-manager";
+import { getErrorMessage } from "./shared";
+import type { CommandContext, CommandResult } from "./cli";
+import type { ProcessDefinition, ServiceState } from "./types";
+
+export interface LifecycleStatus {
+  name: string;
+  state: ServiceState | "UNKNOWN";
+}
+
+export interface LifecycleOperations {
+  start: (name?: string) => Promise<string[]>;
+  status: () => Promise<LifecycleStatus[]>;
+}
+
+export interface LifecycleCommandOptions {
+  cwd?: string;
+  manifestPath?: string;
+  operations?: LifecycleOperations;
+}
+
+const findProcessDefinition = (processDefinitions: ProcessDefinition[], name: string): number =>
+  processDefinitions.findIndex((processDefinition) => processDefinition.name === name);
+
+const createDefaultOperations = (options: LifecycleCommandOptions): LifecycleOperations => {
+  const cwd = options.cwd ?? process.cwd();
+  const manifestPath = options.manifestPath ?? resolve(cwd, "stasium.toml");
+
+  return {
+    start: async (name) => {
+      const manifest = await loadManifest(manifestPath);
+      const manager = new ServiceManager(manifest.services, {
+        processClaimStore: new ProcessClaimStore(cwd),
+      });
+
+      if (name) {
+        const index = findProcessDefinition(manifest.services, name);
+        if (index === -1) throw new Error(`Unknown Managed Process: ${name}`);
+        manager.setSelectedIndex(index);
+        await manager.startSelected();
+        return manager.getServicePids().map((pid) => pid.name);
+      }
+
+      await manager.startAll();
+      return manager.getServicePids().map((pid) => pid.name);
+    },
+    status: async () => {
+      const manifest = await loadManifest(manifestPath);
+      return manifest.services.map((processDefinition) => ({
+        name: processDefinition.name,
+        state: "UNKNOWN",
+      }));
+    },
+  };
+};
+
+export const runStartCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: LifecycleCommandOptions = {},
+): Promise<CommandResult> => {
+  if (args.length > 1) {
+    context.stderr("Usage: stasium start [managed-process-name]");
+    return { exitCode: 1 };
+  }
+
+  try {
+    const started = await (options.operations ?? createDefaultOperations(options)).start(args[0]);
+    if (started.length === 0) {
+      context.stdout("No Direct Managed Processes started.");
+    } else {
+      for (const name of started) context.stdout(`Started ${name}.`);
+    }
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runStatusCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: LifecycleCommandOptions = {},
+): Promise<CommandResult> => {
+  if (args.length > 0) {
+    context.stderr("Usage: stasium status");
+    return { exitCode: 1 };
+  }
+
+  try {
+    const statuses = await (options.operations ?? createDefaultOperations(options)).status();
+    if (statuses.length === 0) {
+      context.stdout("No Managed Processes found.");
+    } else {
+      for (const status of statuses) context.stdout(`${status.name}: ${status.state}`);
+    }
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};

--- a/src/lifecycle-command.ts
+++ b/src/lifecycle-command.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { loadManifest } from "./manifest";
+import { cleanupExistingPids } from "./pidfile";
 import { ProcessClaimStore } from "./process-claim";
 import { ServiceManager } from "./service-manager";
 import { getErrorMessage } from "./shared";
@@ -13,6 +14,8 @@ export interface LifecycleStatus {
 
 export interface LifecycleOperations {
   start: (name?: string) => Promise<string[]>;
+  stop: (name?: string) => Promise<string[]>;
+  restart: (name?: string) => Promise<string[]>;
   status: () => Promise<LifecycleStatus[]>;
 }
 
@@ -47,6 +50,26 @@ const createDefaultOperations = (options: LifecycleCommandOptions): LifecycleOpe
       await manager.startAll();
       return manager.getServicePids().map((pid) => pid.name);
     },
+    stop: async (name) => {
+      const manifest = await loadManifest(manifestPath);
+      if (name && findProcessDefinition(manifest.services, name) === -1) {
+        throw new Error(`Unknown Managed Process: ${name}`);
+      }
+
+      const names = name
+        ? [name]
+        : manifest.services.map((processDefinition) => processDefinition.name);
+      await cleanupExistingPids(cwd, {
+        knownServices: manifest.services.map((processDefinition) => processDefinition.name),
+        targetServices: name ? [name] : undefined,
+      });
+      return names;
+    },
+    restart: async (name) => {
+      const operations = createDefaultOperations(options);
+      await operations.stop(name);
+      return operations.start(name);
+    },
     status: async () => {
       const manifest = await loadManifest(manifestPath);
       return manifest.services.map((processDefinition) => ({
@@ -55,6 +78,56 @@ const createDefaultOperations = (options: LifecycleCommandOptions): LifecycleOpe
       }));
     },
   };
+};
+
+export const runStopCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: LifecycleCommandOptions = {},
+): Promise<CommandResult> => {
+  if (args.length > 1) {
+    context.stderr("Usage: stasium stop [managed-process-name]");
+    return { exitCode: 1 };
+  }
+
+  try {
+    const stopped = await (options.operations ?? createDefaultOperations(options)).stop(args[0]);
+    if (stopped.length === 0) {
+      context.stdout("No Direct Managed Processes stopped.");
+    } else {
+      for (const name of stopped) context.stdout(`Stopped ${name}.`);
+    }
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runRestartCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: LifecycleCommandOptions = {},
+): Promise<CommandResult> => {
+  if (args.length > 1) {
+    context.stderr("Usage: stasium restart [managed-process-name]");
+    return { exitCode: 1 };
+  }
+
+  try {
+    const restarted = await (options.operations ?? createDefaultOperations(options)).restart(
+      args[0],
+    );
+    if (restarted.length === 0) {
+      context.stdout("No Direct Managed Processes restarted.");
+    } else {
+      for (const name of restarted) context.stdout(`Restarted ${name}.`);
+    }
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
 };
 
 export const runStartCommand = async (

--- a/src/pidfile.ts
+++ b/src/pidfile.ts
@@ -231,17 +231,24 @@ type CleanupOptions = {
   logger?: (message: string) => void;
   timeoutMs?: number;
   knownServices?: string[];
+  targetServices?: string[];
 };
 
 export const cleanupExistingPids = async (
   cwd: string,
-  { logger, timeoutMs = DEFAULT_WAIT_MS, knownServices = [] }: CleanupOptions = {},
+  {
+    logger,
+    timeoutMs = DEFAULT_WAIT_MS,
+    knownServices = [],
+    targetServices = [],
+  }: CleanupOptions = {},
 ): Promise<void> => {
   const dir = getPidDir(cwd);
   const pidFiles = await listPidFiles(dir);
   if (pidFiles.length === 0) return;
 
   const known = new Set(knownServices.map((name) => sanitizeServiceName(name)));
+  const targets = new Set(targetServices.map((name) => sanitizeServiceName(name)));
   const pidMap = new Map<
     number,
     { files: string[]; unknownServices: string[]; records: PidFileRecord[] }
@@ -256,6 +263,7 @@ export const cleanupExistingPids = async (
     const pid = getPidFromParsed(parsed);
 
     const serviceName = getServiceNameFromFile(path);
+    if (targets.size > 0 && !targets.has(serviceName)) continue;
     const unknown = known.size > 0 && !known.has(serviceName) ? serviceName : null;
     const entry = pidMap.get(pid);
     if (entry) {

--- a/src/update-command.test.ts
+++ b/src/update-command.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runUpdateCommand } from "./update-command";
+import type { CommandContext } from "./cli";
+import type { UpdateDecision } from "./update-channel";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+const updateAvailable = (
+  channel = "stable",
+): Extract<UpdateDecision, { type: "update-available" }> => ({
+  type: "update-available",
+  currentVersion: "0.1.0",
+  latestVersion: "0.2.0",
+  channel,
+  artifact: {
+    platform: { os: "linux", arch: "x64" },
+    name: "stasium-linux-x64",
+    url: "https://example.com/stasium-linux-x64",
+    sha256: "abc123",
+  },
+});
+
+describe("Update Command", () => {
+  test("reports up-to-date releases", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async (channel) => ({ type: "up-to-date", currentVersion: "0.1.0", channel }),
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual(["Stasium 0.1.0 is up to date on stable."]);
+    expect(io.stderr).toEqual([]);
+  });
+
+  test("installs available updates", async () => {
+    const io = context();
+    let installed = false;
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => updateAvailable(),
+      installUpdate: async () => {
+        installed = true;
+        return { type: "installed", path: "/tmp/stasium" };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(installed).toBe(true);
+    expect(io.stdout).toEqual(["Updated Stasium to 0.2.0. Restart Stasium to use it."]);
+  });
+
+  test("checks without installing", async () => {
+    const io = context();
+    let installed = false;
+    const result = await runUpdateCommand(["--check"], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => updateAvailable(),
+      installUpdate: async () => {
+        installed = true;
+        return { type: "installed", path: "/tmp/stasium" };
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(installed).toBe(false);
+    expect(io.stdout).toEqual(["Stasium 0.2.0 is available on stable."]);
+  });
+
+  test("overrides the update channel for one run", async () => {
+    const io = context();
+    const channels: string[] = [];
+
+    const result = await runUpdateCommand(["--channel", "nightly", "--check"], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async (channel) => {
+        channels.push(channel);
+        return updateAvailable(channel);
+      },
+    });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(channels).toEqual(["nightly"]);
+    expect(io.stdout).toEqual(["Stasium 0.2.0 is available on nightly."]);
+  });
+
+  test("uses the configured update channel by default", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stasium-update-command-"));
+    try {
+      const preferencesPath = join(dir, "update.json");
+      await writeFile(preferencesPath, JSON.stringify({ channel: "beta" }));
+      const io = context();
+      const channels: string[] = [];
+
+      const result = await runUpdateCommand(["--check"], io.context, {
+        currentVersion: "0.1.0",
+        executablePath: "/tmp/stasium",
+        preferencesPath,
+        checkUpdate: async (channel) => {
+          channels.push(channel);
+          return updateAvailable(channel);
+        },
+      });
+
+      expect(result).toEqual({ exitCode: 0 });
+      expect(channels).toEqual(["beta"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("reports unsupported platforms as command failures", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => ({
+        type: "unsupported-platform",
+        currentVersion: "0.1.0",
+        latestVersion: "0.2.0",
+        channel: "stable",
+        platform: { os: "linux", arch: "arm64" },
+      }),
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual([
+      "Stasium 0.2.0 is available, but no linux-arm64 artifact was found.",
+    ]);
+  });
+
+  test("reports channel failures as command failures", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => ({
+        type: "failure",
+        currentVersion: "0.1.0",
+        channel: "stable",
+        reason: "network unavailable",
+      }),
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["network unavailable"]);
+  });
+
+  test("reports automatic update failures", async () => {
+    const io = context();
+    const result = await runUpdateCommand([], io.context, {
+      currentVersion: "0.1.0",
+      executablePath: "/tmp/stasium",
+      checkUpdate: async () => updateAvailable(),
+      installUpdate: async () => ({ type: "failed", reason: "checksum mismatch" }),
+    });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["Stasium update failed: checksum mismatch"]);
+  });
+});

--- a/src/update-command.ts
+++ b/src/update-command.ts
@@ -1,0 +1,121 @@
+import { defaultSelfUpdateTempDir, SelfUpdateInstaller } from "./self-update";
+import { GitHubUpdateChannel } from "./github-update-channel";
+import { getErrorMessage } from "./shared";
+import { currentUpdatePlatform } from "./startup-update";
+import { defaultUpdatePreferencesPath, loadUpdatePreferences } from "./update-preferences";
+import type { UpdateChannelName, UpdateDecision, UpdatePlatform } from "./update-channel";
+import type { SelfUpdateResult } from "./self-update";
+import type { CommandContext, CommandResult } from "./cli";
+
+export interface UpdateCommandOptions {
+  currentVersion: string;
+  executablePath: string;
+  platform?: UpdatePlatform;
+  preferencesPath?: string;
+  checkUpdate?: (channel: UpdateChannelName) => Promise<UpdateDecision>;
+  installUpdate?: (
+    decision: Extract<UpdateDecision, { type: "update-available" }>,
+  ) => Promise<SelfUpdateResult>;
+}
+
+const parseUpdateArgs = (args: string[]): { checkOnly: boolean; channel?: string } => {
+  let checkOnly = false;
+  let channel: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--check") {
+      checkOnly = true;
+      continue;
+    }
+    if (arg === "--channel") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --channel.");
+      channel = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown update option: ${arg}`);
+  }
+
+  return { checkOnly, channel };
+};
+
+const defaultUpdateCheck = (options: UpdateCommandOptions, platform: UpdatePlatform) => {
+  const updateChannel = new GitHubUpdateChannel({ repository: "modoterra/stasium" });
+  return (channel: UpdateChannelName) =>
+    updateChannel.check({ currentVersion: options.currentVersion, channel, platform });
+};
+
+const defaultInstallUpdate = (options: UpdateCommandOptions) => {
+  const installer = new SelfUpdateInstaller({
+    executablePath: options.executablePath,
+    tempDir: defaultSelfUpdateTempDir(options.executablePath),
+  });
+  return (decision: Extract<UpdateDecision, { type: "update-available" }>) =>
+    installer.install(decision.artifact);
+};
+
+export const runUpdateCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: UpdateCommandOptions,
+): Promise<CommandResult> => {
+  let parsed;
+  try {
+    parsed = parseUpdateArgs(args);
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+
+  try {
+    const preferences = await loadUpdatePreferences(
+      options.preferencesPath ?? defaultUpdatePreferencesPath(),
+    );
+    const channel = parsed.channel ?? preferences.channel;
+    const platform = options.platform ?? currentUpdatePlatform();
+    const checkUpdate = options.checkUpdate ?? defaultUpdateCheck(options, platform);
+    const decision = await checkUpdate(channel);
+
+    if (decision.type === "up-to-date") {
+      context.stdout(`Stasium ${decision.currentVersion} is up to date on ${decision.channel}.`);
+      return { exitCode: 0 };
+    }
+
+    if (decision.type === "channel-unavailable" || decision.type === "failure") {
+      context.stderr(decision.reason);
+      return { exitCode: 1 };
+    }
+
+    if (decision.type === "unsupported-platform") {
+      context.stderr(
+        `Stasium ${decision.latestVersion} is available, but no ${decision.platform.os}-${decision.platform.arch} artifact was found.`,
+      );
+      return { exitCode: 1 };
+    }
+
+    if (parsed.checkOnly) {
+      context.stdout(`Stasium ${decision.latestVersion} is available on ${decision.channel}.`);
+      return { exitCode: 0 };
+    }
+
+    const installUpdate = options.installUpdate ?? defaultInstallUpdate(options);
+    const result = await installUpdate(decision);
+    if (result.type === "installed") {
+      context.stdout(`Updated Stasium to ${decision.latestVersion}. Restart Stasium to use it.`);
+      return { exitCode: 0 };
+    }
+    if (result.type === "manual") {
+      context.stdout(`Stasium ${decision.latestVersion} is available: ${result.url}`);
+      context.stderr(`Automatic update unavailable: ${result.reason}`);
+      return { exitCode: 0 };
+    }
+
+    context.stderr(`Stasium update failed: ${result.reason}`);
+    return { exitCode: 1 };
+  } catch (error) {
+    context.stderr(`Stasium update failed: ${getErrorMessage(error)}`);
+    return { exitCode: 1 };
+  }
+};

--- a/src/update-preferences.ts
+++ b/src/update-preferences.ts
@@ -1,4 +1,6 @@
 import { join } from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import type { UpdateChannelName } from "./update-channel";
 
 export interface UpdatePreferences {
@@ -25,4 +27,12 @@ export const loadUpdatePreferences = async (
     enabled: parsed.enabled ?? defaultUpdatePreferences.enabled,
     channel: parsed.channel ?? defaultUpdatePreferences.channel,
   };
+};
+
+export const saveUpdatePreferences = async (
+  preferences: UpdatePreferences,
+  path = defaultUpdatePreferencesPath(),
+): Promise<void> => {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(preferences, null, 2)}\n`);
 };


### PR DESCRIPTION
Closes #137

Stacked on #148.

## Summary

- Added `stasium stop [managed-process-name]` and `stasium restart [managed-process-name]` command handlers.
- Reused Process Claim cleanup for safe Direct Managed Process stopping.
- Added a targeted Process Claim cleanup filter so named stop/restart only acts on the requested Direct Managed Process.
- Added lifecycle command tests for stop and restart output and dispatch.

## Verification

- `bun test src/lifecycle-command.test.ts src/pidfile.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test`
- `bun run build`

## Self Review

Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
