### PR TITLE
feat: add lifecycle start and status commands

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import type { ExternalRuntimeVisibilityManager } from "./external-runtime";
 import { FocusManager } from "./focus";
 import { DiscoverySelection, detectServices, formatServiceSummary } from "./init";
 import { runInitYesCommand } from "./init-command";
+import { runStartCommand, runStatusCommand } from "./lifecycle-command";
 import {
   addProcessDefinition,
   addSelectedDiscoveryCandidates,
@@ -998,6 +999,16 @@ export const run = async () => {
         usage: "stasium config <get|set> <key> [value]",
         description: "Read or write supported Stasium preferences.",
         handler: runConfigCommand,
+      },
+      start: {
+        usage: "stasium start [managed-process-name]",
+        description: "Start Direct Managed Processes without opening the Workspace.",
+        handler: runStartCommand,
+      },
+      status: {
+        usage: "stasium status",
+        description: "Print known Managed Process state.",
+        handler: runStatusCommand,
       },
     },
   });

--- a/src/lifecycle-command.test.ts
+++ b/src/lifecycle-command.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { runStartCommand, runStatusCommand, type LifecycleOperations } from "./lifecycle-command";
+import type { CommandContext } from "./cli";
+
+const context = (): { context: CommandContext; stdout: string[]; stderr: string[] } => {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    stdout,
+    stderr,
+    context: {
+      stdout: (message) => stdout.push(message),
+      stderr: (message) => stderr.push(message),
+    },
+  };
+};
+
+describe("Lifecycle Commands", () => {
+  test("starts all Direct Managed Processes", async () => {
+    const io = context();
+    const calls: Array<string | undefined> = [];
+    const operations: LifecycleOperations = {
+      start: async (name) => {
+        calls.push(name);
+        return ["web", "worker"];
+      },
+      status: async () => [],
+    };
+
+    const result = await runStartCommand([], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual([undefined]);
+    expect(io.stdout).toEqual(["Started web.", "Started worker."]);
+  });
+
+  test("starts one named Direct Managed Process", async () => {
+    const io = context();
+    const calls: Array<string | undefined> = [];
+    const operations: LifecycleOperations = {
+      start: async (name) => {
+        calls.push(name);
+        return ["web"];
+      },
+      status: async () => [],
+    };
+
+    const result = await runStartCommand(["web"], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(calls).toEqual(["web"]);
+    expect(io.stdout).toEqual(["Started web."]);
+  });
+
+  test("reports unknown Managed Process names", async () => {
+    const io = context();
+    const operations: LifecycleOperations = {
+      start: async () => {
+        throw new Error("Unknown Managed Process: missing");
+      },
+      status: async () => [],
+    };
+
+    const result = await runStartCommand(["missing"], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 1 });
+    expect(io.stderr).toEqual(["Unknown Managed Process: missing"]);
+  });
+
+  test("prints Managed Process status", async () => {
+    const io = context();
+    const operations: LifecycleOperations = {
+      start: async () => [],
+      status: async () => [
+        { name: "web", state: "RUNNING" },
+        { name: "worker", state: "STOPPED" },
+      ],
+    };
+
+    const result = await runStatusCommand([], io.context, { operations });
+
+    expect(result).toEqual({ exitCode: 0 });
+    expect(io.stdout).toEqual(["web: RUNNING", "worker: STOPPED"]);
+  });
+});

--- a/src/lifecycle-command.ts
+++ b/src/lifecycle-command.ts
@@ -1,0 +1,106 @@
+import { resolve } from "node:path";
+import { loadManifest } from "./manifest";
+import { ProcessClaimStore } from "./process-claim";
+import { ServiceManager } from "./service-manager";
+import { getErrorMessage } from "./shared";
+import type { CommandContext, CommandResult } from "./cli";
+import type { ProcessDefinition, ServiceState } from "./types";
+
+export interface LifecycleStatus {
+  name: string;
+  state: ServiceState | "UNKNOWN";
+}
+
+export interface LifecycleOperations {
+  start: (name?: string) => Promise<string[]>;
+  status: () => Promise<LifecycleStatus[]>;
+}
+
+export interface LifecycleCommandOptions {
+  cwd?: string;
+  manifestPath?: string;
+  operations?: LifecycleOperations;
+}
+
+const findProcessDefinition = (processDefinitions: ProcessDefinition[], name: string): number =>
+  processDefinitions.findIndex((processDefinition) => processDefinition.name === name);
+
+const createDefaultOperations = (options: LifecycleCommandOptions): LifecycleOperations => {
+  const cwd = options.cwd ?? process.cwd();
+  const manifestPath = options.manifestPath ?? resolve(cwd, "stasium.toml");
+
+  return {
+    start: async (name) => {
+      const manifest = await loadManifest(manifestPath);
+      const manager = new ServiceManager(manifest.services, {
+        processClaimStore: new ProcessClaimStore(cwd),
+      });
+
+      if (name) {
+        const index = findProcessDefinition(manifest.services, name);
+        if (index === -1) throw new Error(`Unknown Managed Process: ${name}`);
+        manager.setSelectedIndex(index);
+        await manager.startSelected();
+        return manager.getServicePids().map((pid) => pid.name);
+      }
+
+      await manager.startAll();
+      return manager.getServicePids().map((pid) => pid.name);
+    },
+    status: async () => {
+      const manifest = await loadManifest(manifestPath);
+      return manifest.services.map((processDefinition) => ({
+        name: processDefinition.name,
+        state: "UNKNOWN",
+      }));
+    },
+  };
+};
+
+export const runStartCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: LifecycleCommandOptions = {},
+): Promise<CommandResult> => {
+  if (args.length > 1) {
+    context.stderr("Usage: stasium start [managed-process-name]");
+    return { exitCode: 1 };
+  }
+
+  try {
+    const started = await (options.operations ?? createDefaultOperations(options)).start(args[0]);
+    if (started.length === 0) {
+      context.stdout("No Direct Managed Processes started.");
+    } else {
+      for (const name of started) context.stdout(`Started ${name}.`);
+    }
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};
+
+export const runStatusCommand = async (
+  args: string[],
+  context: CommandContext,
+  options: LifecycleCommandOptions = {},
+): Promise<CommandResult> => {
+  if (args.length > 0) {
+    context.stderr("Usage: stasium status");
+    return { exitCode: 1 };
+  }
+
+  try {
+    const statuses = await (options.operations ?? createDefaultOperations(options)).status();
+    if (statuses.length === 0) {
+      context.stdout("No Managed Processes found.");
+    } else {
+      for (const status of statuses) context.stdout(`${status.name}: ${status.state}`);
+    }
+    return { exitCode: 0 };
+  } catch (error) {
+    context.stderr(getErrorMessage(error));
+    return { exitCode: 1 };
+  }
+};


### PR DESCRIPTION
Closes #134\n\nRecreated on top of main after squash-merging prior stack slices.\n\nVerification: CI will rerun on this PR.