### PR TITLE
feat: add platform-aware website install section

### DIFF
--- a/web/components/copy-command.tsx
+++ b/web/components/copy-command.tsx
@@ -1,0 +1,41 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+type CopyCommandProps = {
+  label: string;
+  command: string;
+};
+
+export function CopyCommand({ label, command }: CopyCommandProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <div className="bg-[#17130f] p-4 text-left text-[#fffdf7] dark:bg-[#f4efe4] dark:text-[#11110f]">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <p className="font-['JetBrains_Mono_Variable'] text-xs uppercase tracking-[0.12em] opacity-70">
+          {label}
+        </p>
+        <Button
+          className="h-8 rounded-full bg-white/10 px-3 text-xs text-current hover:bg-white/20 dark:bg-black/10 dark:hover:bg-black/20"
+          size="sm"
+          variant="ghost"
+          onClick={copy}
+        >
+          {copied ? <Check className="mr-2 size-3" /> : <Copy className="mr-2 size-3" />}
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap font-['JetBrains_Mono_Variable'] text-sm leading-7">
+        <code>{command}</code>
+      </pre>
+    </div>
+  );
+}

--- a/web/components/install-section.test.tsx
+++ b/web/components/install-section.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { InstallSection } from "./install-section";
+
+const setNavigator = (platform: string, userAgent: string) => {
+  Object.defineProperty(window.navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  Object.defineProperty(window.navigator, "userAgent", {
+    configurable: true,
+    value: userAgent,
+  });
+};
+
+describe("InstallSection", () => {
+  beforeEach(() => {
+    setNavigator("Linux x86_64", "X11; Linux x86_64");
+  });
+
+  test("shows recommended and manual release downloads", () => {
+    render(<InstallSection />);
+
+    expect(screen.getByRole("link", { name: /download for linux x64/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("stasium-linux-x64"),
+    );
+    expect(screen.getByRole("link", { name: /^macos$/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /linux arm64/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /windows/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /verify with checksums/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("checksums.txt"),
+    );
+  });
+
+  test("copies source build instructions", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+    render(<InstallSection />);
+
+    await user.click(screen.getAllByRole("button", { name: /copy/i })[1]!);
+
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("bun run build:cli"));
+    await waitFor(() => expect(screen.getByText("Copied")).toBeInTheDocument());
+  });
+});

--- a/web/components/install-section.tsx
+++ b/web/components/install-section.tsx
@@ -1,0 +1,89 @@
+import { Download, ShieldCheck } from "lucide-react";
+
+import {
+  afterDownloadCommand,
+  checksumsUrl,
+  downloadOptions,
+  latestReleaseUrl,
+  sourceBuildCommand,
+} from "../data/downloads";
+import { usePlatformDownload } from "../hooks/use-platform-download";
+import { CopyCommand } from "./copy-command";
+
+export function InstallSection() {
+  const recommended = usePlatformDownload();
+
+  return (
+    <section id="install" className="scroll-mt-28 bg-[#fbfbf7] px-4 pt-36 dark:bg-[#101113]">
+      <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mx-auto inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
+            <Download className="size-4" /> Install
+          </div>
+          <h2 className="mt-7 text-balance text-[clamp(2.5rem,5vw,5rem)] font-semibold leading-[0.98] tracking-[-0.06em]">
+            Get Stasium onto your path.
+          </h2>
+          <p className="mx-auto mt-6 max-w-2xl text-xl leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+            Download a release binary, make it executable, and run `stasium` in your Project.
+          </p>
+        </div>
+
+        <div className="mt-16 grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="bg-white p-6 shadow-[0_1px_0_rgba(0,0,0,0.08)] dark:bg-white/5 dark:shadow-none">
+            <p className="font-['JetBrains_Mono_Variable'] text-xs uppercase tracking-[0.12em] text-[#6a625d] dark:text-[#c9c2ba]">
+              Recommended download
+            </p>
+            <h3 className="mt-5 text-3xl font-semibold tracking-[-0.05em]">{recommended.label}</h3>
+            <p className="mt-3 font-['JetBrains_Mono_Variable'] text-sm text-[#6f6862] dark:text-[#c8c1b8]">
+              {recommended.fileName}
+            </p>
+            <a
+              className="mt-8 inline-flex w-full items-center justify-center bg-[#155cff] px-6 py-4 font-semibold text-white transition hover:bg-[#0047e8]"
+              href={recommended.href}
+            >
+              {recommended.id === "unknown"
+                ? "View all releases"
+                : `Download for ${recommended.shortLabel}`}
+              <Download className="ml-2 size-4" />
+            </a>
+
+            <div className="mt-8 flex flex-wrap gap-2 text-sm">
+              {downloadOptions.map((option) => (
+                <a
+                  key={option.id}
+                  className="bg-[#f0eadf] px-3 py-2 text-[#4d453e] hover:text-[#155cff] dark:bg-white/10 dark:text-[#d8d0c6] dark:hover:text-[#6ea0ff]"
+                  href={option.href}
+                >
+                  {option.shortLabel}
+                </a>
+              ))}
+              <a
+                className="bg-[#f0eadf] px-3 py-2 text-[#4d453e] hover:text-[#155cff] dark:bg-white/10 dark:text-[#d8d0c6] dark:hover:text-[#6ea0ff]"
+                href={latestReleaseUrl}
+              >
+                All releases
+              </a>
+            </div>
+
+            <a
+              className="mt-6 inline-flex items-center text-sm font-medium text-[#155cff] dark:text-[#6ea0ff]"
+              href={checksumsUrl}
+            >
+              <ShieldCheck className="mr-2 size-4" /> Verify with checksums.txt
+            </a>
+
+            <p className="mt-6 text-sm leading-6 text-[#6f6862] dark:text-[#c8c1b8]">
+              Windows: download `stasium-windows-x64.exe`, rename it to `stasium.exe` if you want,
+              and run it from PowerShell or place it on PATH.
+            </p>
+          </div>
+
+          <div className="grid gap-5">
+            <CopyCommand label="After download on macOS/Linux" command={afterDownloadCommand} />
+            <CopyCommand label="Build from source" command={sourceBuildCommand} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/data/downloads.ts
+++ b/web/data/downloads.ts
@@ -1,0 +1,60 @@
+const releaseDownloadBase = "https://github.com/modoterra/stasium/releases/latest/download";
+
+export const latestReleaseUrl = "https://github.com/modoterra/stasium/releases/latest";
+export const checksumsUrl = `${releaseDownloadBase}/checksums.txt`;
+
+export type DownloadId = "macos-arm64" | "linux-x64" | "linux-arm64" | "windows-x64" | "unknown";
+
+export type DownloadOption = {
+  id: DownloadId;
+  label: string;
+  shortLabel: string;
+  href: string;
+  fileName: string;
+};
+
+export const downloadOptions: DownloadOption[] = [
+  {
+    id: "macos-arm64",
+    label: "macOS Apple Silicon",
+    shortLabel: "macOS",
+    href: `${releaseDownloadBase}/stasium-macos-arm64`,
+    fileName: "stasium-macos-arm64",
+  },
+  {
+    id: "linux-x64",
+    label: "Linux x64",
+    shortLabel: "Linux x64",
+    href: `${releaseDownloadBase}/stasium-linux-x64`,
+    fileName: "stasium-linux-x64",
+  },
+  {
+    id: "linux-arm64",
+    label: "Linux ARM64",
+    shortLabel: "Linux ARM64",
+    href: `${releaseDownloadBase}/stasium-linux-arm64`,
+    fileName: "stasium-linux-arm64",
+  },
+  {
+    id: "windows-x64",
+    label: "Windows x64",
+    shortLabel: "Windows",
+    href: `${releaseDownloadBase}/stasium-windows-x64.exe`,
+    fileName: "stasium-windows-x64.exe",
+  },
+];
+
+export const unknownDownload: DownloadOption = {
+  id: "unknown",
+  label: "All releases",
+  shortLabel: "All releases",
+  href: latestReleaseUrl,
+  fileName: "GitHub Releases",
+};
+
+export const findDownload = (id: DownloadId) =>
+  downloadOptions.find((option) => option.id === id) ?? unknownDownload;
+
+export const afterDownloadCommand = `chmod +x stasium-*\nsudo mv stasium-* /usr/local/bin/stasium\nstasium`;
+
+export const sourceBuildCommand = `git clone https://github.com/modoterra/stasium.git\ncd stasium\nbun install\nbun run build:cli\n./dist/stasium\n\n# optional: install on PATH\nsudo mv ./dist/stasium /usr/local/bin/stasium\nstasium`;

--- a/web/hooks/use-platform-download.test.ts
+++ b/web/hooks/use-platform-download.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import { detectDownloadId } from "./use-platform-download";
+
+const nav = (platform: string, userAgent = "") => ({ platform, userAgent }) as Navigator;
+
+describe("detectDownloadId", () => {
+  test("detects macOS as Apple Silicon download", () => {
+    expect(detectDownloadId(nav("MacIntel"))).toBe("macos-arm64");
+  });
+
+  test("detects Linux x64", () => {
+    expect(detectDownloadId(nav("Linux x86_64", "X11; Linux x86_64"))).toBe("linux-x64");
+  });
+
+  test("detects Linux ARM64", () => {
+    expect(detectDownloadId(nav("Linux arm64", "Linux aarch64"))).toBe("linux-arm64");
+  });
+
+  test("detects Windows x64", () => {
+    expect(detectDownloadId(nav("Win32", "Windows NT 10.0; Win64; x64"))).toBe("windows-x64");
+  });
+
+  test("falls back for unknown platforms", () => {
+    expect(detectDownloadId(nav("FreeBSD"))).toBe("unknown");
+  });
+});

--- a/web/hooks/use-platform-download.ts
+++ b/web/hooks/use-platform-download.ts
@@ -1,0 +1,41 @@
+import { useMemo } from "react";
+
+import { findDownload, type DownloadId } from "../data/downloads";
+
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
+const normalize = (value: string | undefined) => value?.toLowerCase() ?? "";
+
+export const detectDownloadId = (navigatorLike: NavigatorWithUserAgentData): DownloadId => {
+  const platform = normalize(navigatorLike.userAgentData?.platform || navigatorLike.platform);
+  const userAgent = normalize(navigatorLike.userAgent);
+  const combined = `${platform} ${userAgent}`;
+
+  if (combined.includes("mac")) return "macos-arm64";
+  if (combined.includes("win")) return "windows-x64";
+
+  if (combined.includes("linux")) {
+    if (combined.includes("aarch64") || combined.includes("arm64")) return "linux-arm64";
+    if (
+      combined.includes("x86_64") ||
+      combined.includes("x64") ||
+      combined.includes("amd64") ||
+      combined.includes("x11")
+    ) {
+      return "linux-x64";
+    }
+  }
+
+  return "unknown";
+};
+
+export function usePlatformDownload() {
+  return useMemo(() => {
+    if (typeof navigator === "undefined") return findDownload("unknown");
+    return findDownload(detectDownloadId(navigator));
+  }, []);
+}

--- a/web/site-app.tsx
+++ b/web/site-app.tsx
@@ -1,9 +1,10 @@
-import { Check, ChevronDown, Download, Sparkles } from "lucide-react";
+import { Check, ChevronDown, Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
 import { FloatingNav } from "./components/floating-nav";
 import { Hero } from "./components/hero";
+import { InstallSection } from "./components/install-section";
 import { useThemePreference } from "./hooks/use-theme-preference";
 
 const painPoints = [
@@ -37,18 +38,7 @@ function SiteApp() {
 
       <Hero />
 
-      <section id="install" className="scroll-mt-28 bg-[#fbfbf7] px-4 pt-36 dark:bg-[#101113]">
-        <div className="mx-auto max-w-7xl">
-          <div className="mx-auto max-w-3xl text-center">
-            <div className="mx-auto inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
-              <Download className="size-4" /> Install
-            </div>
-            <h2 className="mt-7 text-balance text-[clamp(2.5rem,5vw,5rem)] font-semibold leading-[0.98] tracking-[-0.06em]">
-              Get Stasium onto your path.
-            </h2>
-          </div>
-        </div>
-      </section>
+      <InstallSection />
 
       <section id="quickstart" className="scroll-mt-28 bg-[#fbfbf7] px-4 pt-24 dark:bg-[#101113]">
         <div className="mx-auto max-w-7xl">

--- a/web/test/setup.ts
+++ b/web/test/setup.ts
@@ -24,6 +24,14 @@ Object.defineProperty(window, "localStorage", {
   value: createStorage(),
 });
 
+Object.defineProperty(window.navigator, "clipboard", {
+  configurable: true,
+  writable: true,
+  value: {
+    writeText: async () => {},
+  },
+});
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
Closes #165

## Summary

- Adds runtime platform recommendation for release binary downloads.
- Adds manual download links, latest release fallback, and checksum link.
- Adds compact macOS/Linux and Windows post-download instructions.
- Adds source build instructions with copy buttons and inline copied feedback.

## Verification

- `bun run format:check` passed.
- `bun run typecheck` passed.
- `bun run test` passed.
- `bun run build` passed.

## Notes

- This is stacked on #172 because #165 depends on #162 and the website structure stack.
- Pre-existing unrelated dirty files were left uncommitted: `.gitignore`, `README.md`, `tsconfig.app.json`, `eslint.config.js`, and `public/icons.svg`.
- Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
