### PR TITLE
feat: add current detects website section

### DIFF
--- a/web/components/detects-section.test.tsx
+++ b/web/components/detects-section.test.tsx
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { detectedStacks, packageManagers } from "../data/detects";
+import { DetectsSection } from "./detects-section";
+
+const strategiesToml = readFileSync(join(process.cwd(), "src/discovery/strategies.toml"), "utf8");
+const capturesTs = readFileSync(join(process.cwd(), "src/discovery/captures.ts"), "utf8");
+const dockerTs = readFileSync(join(process.cwd(), "src/docker.ts"), "utf8");
+
+describe("DetectsSection", () => {
+  test("uses detects and shows language without broad support claims", () => {
+    render(<DetectsSection />);
+
+    expect(screen.getByText(/Detects common setups/i)).toBeInTheDocument();
+    expect(screen.getByText(/Shows what it finds/i)).toBeInTheDocument();
+    expect(screen.getByText(/accept, edit, or skip/i)).toBeInTheDocument();
+    expect(screen.queryByText(/supports/i)).not.toBeInTheDocument();
+  });
+
+  test("renders current discovery coverage", () => {
+    render(<DetectsSection />);
+
+    for (const stack of detectedStacks) {
+      expect(screen.getByText(stack.title)).toBeInTheDocument();
+    }
+
+    for (const term of [
+      /app/i,
+      /queue/i,
+      /scheduler/i,
+      /Reverb/i,
+      /Octane/i,
+      /Horizon/i,
+      /Pulse/i,
+      /Rails/i,
+      /Django/i,
+      /FastAPI/i,
+      /dev, start, watch, or serve/i,
+      /worker, queue, jobs, or background/i,
+      /air/i,
+      /go run/i,
+      /make dev/i,
+      /External Runtime Visibility/i,
+      /Direct Managed Processes/i,
+      /Stasium Process Ownership/i,
+      /add missing commands to the Manifest/i,
+    ]) {
+      expect(screen.getAllByText(term).length).toBeGreaterThan(0);
+    }
+  });
+
+  test("content maps to current Discovery and External Runtime Visibility code", () => {
+    for (const strategyId of [
+      "laravel-app",
+      "laravel-queue",
+      "laravel-scheduler",
+      "laravel-reverb",
+      "laravel-octane",
+      "laravel-horizon",
+      "laravel-pulse-check",
+      "rails-app",
+      "django-app",
+      "fastapi-main",
+      "fastapi-app-main",
+      "node-dev",
+      "node-worker",
+      "go-air",
+      "go-run",
+      "make-dev",
+    ]) {
+      expect(strategiesToml).toContain(`id = "${strategyId}"`);
+    }
+
+    for (const manager of packageManagers) {
+      expect(capturesTs).toContain(`"${manager}"`);
+    }
+
+    expect(dockerTs).toContain("createDockerComposeExternalRuntimeAdapter");
+    expect(dockerTs).toContain("docker-compose");
+  });
+});

--- a/web/components/detects-section.tsx
+++ b/web/components/detects-section.tsx
@@ -1,0 +1,74 @@
+import { Sparkles } from "lucide-react";
+
+import { detectedStacks, dockerComposeVisibility, packageManagers } from "../data/detects";
+
+export function DetectsSection() {
+  return (
+    <section id="detects" className="scroll-mt-28 bg-[#fbfbf7] px-4 pt-24 dark:bg-[#101113]">
+      <div className="mx-auto max-w-7xl">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mx-auto inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
+            <Sparkles className="size-4" /> Detects common setups
+          </div>
+          <h2 className="mt-7 text-balance text-[clamp(2.5rem,5vw,5rem)] font-semibold leading-[0.98] tracking-[-0.06em]">
+            Shows what it finds.
+          </h2>
+          <p className="mx-auto mt-6 max-w-2xl text-xl leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+            Discovery looks for familiar Project files and proposes commands you can accept, edit,
+            or skip before they become Manifest entries.
+          </p>
+        </div>
+
+        <div className="mt-16 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {detectedStacks.map((stack) => (
+            <article key={stack.title} className="bg-white p-6 dark:bg-white/5">
+              <h3 className="text-2xl font-semibold tracking-[-0.04em]">{stack.title}</h3>
+              <p className="mt-5 text-lg leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+                {stack.body}
+              </p>
+              <p className="mt-4 font-['JetBrains_Mono_Variable'] text-sm leading-6 text-[#7b746d] dark:text-[#bfb7ae]">
+                {stack.detail}
+              </p>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-5 grid gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <article className="bg-[#155cff] p-6 text-white">
+            <h3 className="text-2xl font-semibold tracking-[-0.04em]">Node package managers</h3>
+            <p className="mt-5 text-lg leading-8 text-white/80">
+              Node script proposals pick the package manager from lockfiles when available.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-2">
+              {packageManagers.map((manager) => (
+                <span
+                  key={manager}
+                  className="bg-white/15 px-3 py-2 font-['JetBrains_Mono_Variable'] text-sm"
+                >
+                  {manager}
+                </span>
+              ))}
+            </div>
+          </article>
+
+          <article className="bg-[#efefea] p-6 dark:bg-white/10">
+            <h3 className="text-2xl font-semibold tracking-[-0.04em]">
+              {dockerComposeVisibility.title}
+            </h3>
+            <p className="mt-5 text-lg leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+              {dockerComposeVisibility.body}
+            </p>
+          </article>
+        </div>
+
+        <div className="mt-5 border border-[#d8d2c8] bg-transparent p-6 dark:border-white/15">
+          <h3 className="text-2xl font-semibold tracking-[-0.04em]">Don't see your stack?</h3>
+          <p className="mt-4 text-lg leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+            Accept what Discovery finds, then add missing commands to the Manifest as your Project
+            changes.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/data/detects.ts
+++ b/web/data/detects.ts
@@ -1,0 +1,45 @@
+export const detectedStacks = [
+  {
+    title: "Laravel",
+    body: "Looks for artisan and composer.json, then shows app, queue, scheduler, and Reverb commands when the Project has them.",
+    detail: "Optional package clues can also show Octane, Horizon, and Pulse check commands.",
+  },
+  {
+    title: "Rails",
+    body: "Looks for Gemfile, config/application.rb, and bin/rails, then shows a Rails server command.",
+    detail: "The proposed command uses bin/rails server.",
+  },
+  {
+    title: "Django",
+    body: "Looks for manage.py plus common Python dependency files, then shows the development server.",
+    detail: "The proposed command uses python manage.py runserver.",
+  },
+  {
+    title: "FastAPI",
+    body: "Looks for FastAPI() in main.py or app/main.py, then shows a reloadable uvicorn command.",
+    detail: "The proposed command targets main:app or app.main:app.",
+  },
+  {
+    title: "Node package scripts",
+    body: "Looks for package.json scripts and shows the first available dev, start, watch, or serve command.",
+    detail:
+      "Worker-like scripts named worker, queue, jobs, or background can appear as optional proposals.",
+  },
+  {
+    title: "Go",
+    body: "Looks for go.mod and either .air.toml or a main.go entrypoint.",
+    detail: "Projects with air get air; other entrypoint projects can show go run .",
+  },
+  {
+    title: "Make",
+    body: "Looks for a Makefile with a dev target.",
+    detail: "The proposed command is make dev.",
+  },
+];
+
+export const packageManagers = ["npm", "pnpm", "yarn", "bun"];
+
+export const dockerComposeVisibility = {
+  title: "Docker Compose",
+  body: "Compose services are shown through External Runtime Visibility. Docker keeps process ownership; Stasium does not turn them into Direct Managed Processes with Stasium Process Ownership.",
+};

--- a/web/site-app.tsx
+++ b/web/site-app.tsx
@@ -1,34 +1,11 @@
-import { Check, ChevronDown, Sparkles } from "lucide-react";
+import { Check } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-
+import { DetectsSection } from "./components/detects-section";
 import { FloatingNav } from "./components/floating-nav";
 import { Hero } from "./components/hero";
 import { InstallSection } from "./components/install-section";
 import { QuickstartSection } from "./components/quickstart-section";
 import { useThemePreference } from "./hooks/use-theme-preference";
-
-const painPoints = [
-  {
-    title: "Tab roulette",
-    body: "Your dev server, queue worker, tests, and database logs all live in separate terminal tabs.",
-  },
-  {
-    title: "Scattered output",
-    body: "Process Output split across terminals makes it hard to see what changed and what failed.",
-  },
-  {
-    title: "Unknown state",
-    body: "Green, red, crashed, idle. Stasium keeps local process state visible in one terminal.",
-  },
-];
-
-const services = [
-  { name: "web", state: "running", color: "bg-[#35b957]" },
-  { name: "queue", state: "running", color: "bg-[#35b957]" },
-  { name: "tests", state: "crashed", color: "bg-[#ef3f3f]" },
-  { name: "postgres", state: "ready", color: "bg-[#35b957]" },
-];
 
 function SiteApp() {
   const { isDark, toggleTheme } = useThemePreference();
@@ -43,72 +20,7 @@ function SiteApp() {
 
       <QuickstartSection />
 
-      <section id="detects" className="scroll-mt-28 bg-[#fbfbf7] px-4 pt-24 dark:bg-[#101113]">
-        <div className="mx-auto max-w-7xl">
-          <div className="mx-auto max-w-3xl text-center">
-            <div className="mx-auto inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
-              <Sparkles className="size-4" /> The issue
-            </div>
-            <h2 className="mt-7 text-balance text-[clamp(2.5rem,5vw,5rem)] font-semibold leading-[0.98] tracking-[-0.06em]">
-              Your local stack needs one home.
-            </h2>
-            <p className="mt-6 text-pretty text-xl leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
-              Stasium gives every process a place: status, logs, restart behavior, startup order,
-              and shutdown all move together.
-            </p>
-          </div>
-
-          <div className="mt-20 grid gap-4 md:grid-cols-3">
-            {painPoints.map((point) => (
-              <article
-                key={point.title}
-                className="bg-white p-8 shadow-[0_1px_0_rgba(0,0,0,0.08)] dark:bg-white/5 dark:shadow-none"
-              >
-                <h3 className="text-2xl font-semibold tracking-[-0.04em]">{point.title}</h3>
-                <p className="mt-5 text-lg leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
-                  {point.body}
-                </p>
-              </article>
-            ))}
-          </div>
-
-          <div className="mt-24 grid items-center gap-12 lg:grid-cols-[1fr_0.8fr]">
-            <div>
-              <div className="inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
-                <Check className="size-4" /> The fix
-              </div>
-              <h2 className="mt-7 max-w-3xl text-balance text-[clamp(2.8rem,6vw,6rem)] font-semibold leading-[0.96] tracking-[-0.065em]">
-                One terminal. Full visibility.
-              </h2>
-              <p className="mt-8 max-w-2xl text-xl leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
-                Define your stack once. Start it once. Keep Process Output visible instead of
-                guessing whether the world is on fire.
-              </p>
-            </div>
-
-            <div className="bg-white p-5 shadow-[0_24px_70px_rgba(0,0,0,0.12)] dark:bg-[#17191d]">
-              {services.map((service) => (
-                <div key={service.name} className="flex items-center justify-between py-4">
-                  <div className="flex items-center gap-3">
-                    <span className={`size-2 rounded-full ${service.color}`} />
-                    <span className="text-xl font-semibold tracking-[-0.04em]">{service.name}</span>
-                  </div>
-                  <span className="font-['JetBrains_Mono_Variable'] text-sm text-[#7b746d] dark:text-[#bfb7ae]">
-                    {service.state}
-                  </span>
-                </div>
-              ))}
-              <Button
-                className="mt-4 w-full rounded-none bg-[#155cff] text-white hover:bg-[#0047e8]"
-                size="lg"
-              >
-                Start workspace
-                <ChevronDown className="ml-2 size-4" />
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
+      <DetectsSection />
 
       <section id="manifest" className="scroll-mt-28 bg-[#fbfbf7] px-4 py-28 dark:bg-[#101113]">
         <div className="mx-auto max-w-7xl">


### PR DESCRIPTION
Closes #167

## Summary

- Replaces the detects placeholder with a current-state accurate Discovery coverage section.
- Uses "detects" and "shows" language and avoids broad support claims.
- Covers Laravel, Rails, Django, FastAPI, Node scripts/package managers, Go, Make, and Docker Compose as External Runtime Visibility.
- Adds a "Don't see your stack?" note about accepting Discovery results and editing the Manifest.
- Adds content tests that compare the section claims to the current Discovery strategy and Docker Compose runtime code.

## Verification

- `bun run format:check` passed.
- `bun run typecheck` passed.
- `bun run test` passed.
- `bun run build` passed.

## Notes

- This is stacked on #174 because #167 depends on the website structure stack.
- Pre-existing unrelated dirty files were left uncommitted: `.gitignore`, `README.md`, `tsconfig.app.json`, `eslint.config.js`, and `public/icons.svg`.
- Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
