### PR TITLE
feat: add manifest transparency website section

### DIFF
--- a/web/components/manifest-section.test.tsx
+++ b/web/components/manifest-section.test.tsx
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+
+import { manifestExample } from "../data/manifest-example";
+import { ManifestSection } from "./manifest-section";
+
+const manifestImplementation = readFileSync(join(process.cwd(), "src/manifest.ts"), "utf8");
+
+describe("ManifestSection", () => {
+  test("explains accepted candidates become editable manifest process definitions", () => {
+    render(<ManifestSection />);
+
+    expect(screen.getByText(/accepted Candidates become Process Definitions/i)).toBeInTheDocument();
+    expect(screen.getByText(/plain TOML/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit the Manifest directly/i)).toBeInTheDocument();
+    expect(screen.queryByText(/write a Manifest first/i)).not.toBeInTheDocument();
+  });
+
+  test("shows a small mixed-stack manifest example", () => {
+    render(<ManifestSection />);
+
+    expect(screen.getByText(/stasium.toml/i)).toBeInTheDocument();
+    expect(screen.getByText(/name = "web"/i)).toBeInTheDocument();
+    expect(screen.getByText(/command = \["bun", "run", "dev"\]/i)).toBeInTheDocument();
+    expect(screen.getByText(/name = "queue"/i)).toBeInTheDocument();
+    expect(screen.getByText(/command = \["php", "artisan", "queue:work"\]/i)).toBeInTheDocument();
+    expect(screen.getByText(/depends_on = \["web"\]/i)).toBeInTheDocument();
+  });
+
+  test("example uses keys accepted by the current manifest implementation", () => {
+    for (const key of ["name", "command", "working_dir", "restart_policy", "depends_on"]) {
+      expect(manifestExample).toContain(key);
+      expect(manifestImplementation).toContain(`"${key}"`);
+    }
+
+    expect(manifestExample).toContain("[[service]]");
+    expect(manifestImplementation).toContain("service?: RawServiceConfig[]");
+  });
+});

--- a/web/components/manifest-section.tsx
+++ b/web/components/manifest-section.tsx
@@ -1,0 +1,36 @@
+import { FileText } from "lucide-react";
+
+import { manifestExample } from "../data/manifest-example";
+import { CopyCommand } from "./copy-command";
+
+export function ManifestSection() {
+  return (
+    <section id="manifest" className="scroll-mt-28 bg-[#fbfbf7] px-4 py-28 dark:bg-[#101113]">
+      <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+        <div>
+          <div className="inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
+            <FileText className="size-4" /> Manifest
+          </div>
+          <h2 className="mt-7 text-balance text-[clamp(2.5rem,5vw,5rem)] font-semibold leading-[0.98] tracking-[-0.06em]">
+            Nothing hidden.
+          </h2>
+          <p className="mt-6 max-w-2xl text-xl leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+            Choose the commands Discovery finds, and Stasium writes them down in plain TOML. Those
+            accepted Candidates become Process Definitions in the Manifest.
+          </p>
+          <p className="mt-5 max-w-2xl text-lg leading-8 text-[#6f6862] dark:text-[#c8c1b8]">
+            As your Project changes, edit the Manifest directly and keep local startup transparent.
+          </p>
+        </div>
+
+        <div>
+          <CopyCommand label="stasium.toml" command={manifestExample} />
+          <p className="mt-4 text-sm leading-6 text-[#6f6862] dark:text-[#c8c1b8]">
+            This tiny mixed-stack example uses the current schema: a Node web process plus a
+            Laravel/PHP queue process with a Startup Dependency.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/data/manifest-example.ts
+++ b/web/data/manifest-example.ts
@@ -1,0 +1,11 @@
+export const manifestExample = `[[service]]
+name = "web"
+command = ["bun", "run", "dev"]
+working_dir = "."
+restart_policy = "on-failure"
+
+[[service]]
+name = "queue"
+command = ["php", "artisan", "queue:work"]
+working_dir = "."
+depends_on = ["web"]`;

--- a/web/site-app.tsx
+++ b/web/site-app.tsx
@@ -1,9 +1,8 @@
-import { Check } from "lucide-react";
-
 import { DetectsSection } from "./components/detects-section";
 import { FloatingNav } from "./components/floating-nav";
 import { Hero } from "./components/hero";
 import { InstallSection } from "./components/install-section";
+import { ManifestSection } from "./components/manifest-section";
 import { QuickstartSection } from "./components/quickstart-section";
 import { useThemePreference } from "./hooks/use-theme-preference";
 
@@ -22,18 +21,7 @@ function SiteApp() {
 
       <DetectsSection />
 
-      <section id="manifest" className="scroll-mt-28 bg-[#fbfbf7] px-4 py-28 dark:bg-[#101113]">
-        <div className="mx-auto max-w-7xl">
-          <div className="mx-auto max-w-3xl text-center">
-            <div className="mx-auto inline-flex items-center gap-2 bg-[#efefea] px-3 py-2 text-sm text-[#6a625d] dark:bg-white/10 dark:text-[#c9c2ba]">
-              <Check className="size-4" /> Manifest
-            </div>
-            <h2 className="mt-7 text-balance text-[clamp(2.5rem,5vw,5rem)] font-semibold leading-[0.98] tracking-[-0.06em]">
-              Stasium writes down what it finds.
-            </h2>
-          </div>
-        </div>
-      </section>
+      <ManifestSection />
     </main>
   );
 }


### PR DESCRIPTION
Closes #168

## Summary

- Adds a Manifest transparency section explaining accepted Candidates become Process Definitions.
- Shows a small mixed-stack `stasium.toml` example with Node web and Laravel/PHP queue processes.
- Keeps the copy clear that Stasium writes the Manifest after Discovery and users can edit it later.
- Adds rendered/content tests for the explanation and schema example.
- Validated the example with the real `loadManifest` implementation.

## Verification

- `bun run format:check` passed.
- `bun run typecheck` passed.
- `bun run test` passed.
- `bun run build` passed.
- Manifest example was loaded with `loadManifest` successfully.

## Notes

- This is stacked on #175 because #168 depends on the website structure stack.
- Pre-existing unrelated dirty files were left uncommitted: `.gitignore`, `README.md`, `tsconfig.app.json`, `eslint.config.js`, and `public/icons.svg`.
- Self-reviewed diff for scope, secrets, debug logs, and acceptance criteria.
